### PR TITLE
feat: Add Ableton Learning Music links

### DIFF
--- a/HELP-LINKS.json
+++ b/HELP-LINKS.json
@@ -113,6 +113,28 @@
         "title": "Metronome Online",
         "url": "https://www.metronomeonline.com"
       }
+    ],
+    "ableton_lessons": [
+      {
+        "title": "Learning Music (website)",
+        "url": "https://learningmusic.ableton.com/"
+      },
+      {
+        "title": "Beats (lesson)",
+        "url": "https://learningmusic.ableton.com/make-beats/make-beats.html"
+      },
+      {
+        "title": "Notes and Scales (lesson)",
+        "url": "https://learningmusic.ableton.com/notes-and-scales/notes-and-scales.html"
+      },
+      {
+        "title": "Chords (lesson)",
+        "url": "https://learningmusic.ableton.com/chords/chords.html"
+      },
+      {
+        "title": "The Playground (interactive)",
+        "url": "https://learningmusic.ableton.com/the-playground.html"
+      }
     ]
   },
   "songs": {

--- a/docs/HELP-LINKS.json
+++ b/docs/HELP-LINKS.json
@@ -113,6 +113,28 @@
         "title": "Metronome Online",
         "url": "https://www.metronomeonline.com"
       }
+    ],
+    "ableton_lessons": [
+      {
+        "title": "Learning Music (website)",
+        "url": "https://learningmusic.ableton.com/"
+      },
+      {
+        "title": "Beats (lesson)",
+        "url": "https://learningmusic.ableton.com/make-beats/make-beats.html"
+      },
+      {
+        "title": "Notes and Scales (lesson)",
+        "url": "https://learningmusic.ableton.com/notes-and-scales/notes-and-scales.html"
+      },
+      {
+        "title": "Chords (lesson)",
+        "url": "https://learningmusic.ableton.com/chords/chords.html"
+      },
+      {
+        "title": "The Playground (interactive)",
+        "url": "https://learningmusic.ableton.com/the-playground.html"
+      }
     ]
   },
   "songs": {


### PR DESCRIPTION
Adds a new "ableton_lessons" section to the `HELP-LINKS.json` file, providing users with a curated list of resources from the Ableton Learning Music website. This includes links to the main page, as well as specific lessons on beats, notes, scales, and chords.

The changes are applied to both `HELP-LINKS.json` and its duplicate in the `docs` directory to maintain consistency within the project.