### PR TITLE
feat: Implement classroom mode with multiple chord display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useClassroomMode } from './contexts/ClassroomModeContext'
 import ChordWheel from './components/ChordWheel'
 import { useTheme } from './contexts/ThemeContext'
 import ScrollingPractice from './components/practice-mode/ScrollingPractice'
+import ClassroomMode from './components/classroom/ClassroomMode'
 // --- MERGED IMPORTS (from both branches) ---
 import { useUserProfile } from './contexts/UserProfileContext'
 import OnboardingFlow from './components/onboarding/OnboardingFlow'
@@ -52,6 +53,9 @@ function App() {
       </NavLink>
       <NavLink to="/metronome" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
         Metronome
+      </NavLink>
+      <NavLink to="/classroom" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
+        Classroom
       </NavLink>
        <NavLink to="/profile" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
         Profile
@@ -168,6 +172,7 @@ function App() {
             <Route path="/learn" element={<LearningPathway />} />
             <Route path="/wheel" element={<ChordWheel />} />
             <Route path="/metronome" element={<Metronome />} />
+            <Route path="/classroom" element={<ClassroomMode />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/classroom/ClassroomDisplay.tsx
+++ b/src/components/classroom/ClassroomDisplay.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import GuitarDiagram from '../diagrams/GuitarDiagram'
+import PianoDiagram from '../diagrams/PianoDiagram'
+
+interface ChordDefinition {
+  notes: string[];
+  guitarPositions: { string: number; fret: number }[];
+}
+
+interface ClassroomDisplayProps {
+  displayedChords: string[];
+  instrument: 'guitar' | 'piano';
+  chordData: Record<string, ChordDefinition>;
+}
+
+const ClassroomDisplay: React.FC<ClassroomDisplayProps> = ({ displayedChords, instrument, chordData }) => {
+  return (
+    <div className={`grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mt-2`}>
+        {displayedChords.map((chord, index) => {
+          const data = chordData[chord] ?? { notes: [], guitarPositions: [] }
+          return (
+            <div
+              key={index}
+              className="p-2 bg-green-100 dark:bg-green-900/50 rounded-lg text-center"
+            >
+              {instrument === 'guitar' ? (
+                <GuitarDiagram chordName={chord} positions={data.guitarPositions} />
+              ) : (
+                <PianoDiagram chordName={chord} notes={data.notes} />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default ClassroomDisplay

--- a/src/components/classroom/ClassroomMode.tsx
+++ b/src/components/classroom/ClassroomMode.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react'
 import { getDiatonicChords } from '../../utils/music-theory'
 import GuitarDiagram from '../diagrams/GuitarDiagram'
 import PianoDiagram from '../diagrams/PianoDiagram'
+import ClassroomDisplay from '../classroom/ClassroomDisplay'
 
 const keys = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'Db', 'Ab', 'Eb', 'Bb', 'F']
 const progressions = ['I–V–vi–IV', 'vi–IV–I–V', 'ii–V–I', 'I–vi–IV–V']
@@ -30,10 +31,11 @@ const chordData: Record<string, ChordDefinition> = {
   // Add other chords as needed
 };
 
-const CreatorMode: React.FC = () => {
+const ClassroomMode: React.FC = () => {
   const [selectedKey, setSelectedKey] = useState('C')
   const [selectedProgression, setSelectedProgression] = useState('I–V–vi–IV')
   const [instrument, setInstrument] = useState<'guitar' | 'piano'>('guitar')
+  const [displayedChords, setDisplayedChords] = useState<string[]>([])
 
   const generatedChords = useMemo(() => {
     const diatonic = getDiatonicChords(selectedKey)
@@ -92,6 +94,14 @@ const CreatorMode: React.FC = () => {
             <button onClick={() => setInstrument('piano')} className={`px-3 py-1 text-sm rounded-md ${instrument === 'piano' ? 'bg-white dark:bg-gray-900' : ''}`}>Piano</button>
           </div>
         </div>
+        <div>
+          <button
+            onClick={() => setDisplayedChords(prev => [...prev, ...generatedChords])}
+            className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+          >
+            Add to Display
+          </button>
+        </div>
       </div>
       <div className="mt-6">
         <h4 className="font-bold text-gray-700 dark:text-gray-200">Generated Progression:</h4>
@@ -113,8 +123,21 @@ const CreatorMode: React.FC = () => {
           })}
         </div>
       </div>
+
+      <div className="mt-8">
+        <div className="flex justify-between items-center mb-4">
+          <h4 className="font-bold text-gray-700 dark:text-gray-200">Displayed Chords:</h4>
+          <button
+            onClick={() => setDisplayedChords([])}
+            className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+          >
+            Clear
+          </button>
+        </div>
+        <ClassroomDisplay displayedChords={displayedChords} instrument={instrument} chordData={chordData} />
+      </div>
     </div>
   )
 }
 
-export default CreatorMode
+export default ClassroomMode


### PR DESCRIPTION
This commit introduces a new classroom mode that allows teachers to display multiple chords for either guitar or piano.

The main changes are:
- A new `/classroom` route and navigation link have been added.
- The `CreatorMode` component has been repurposed and renamed to `ClassroomMode` to serve as the main interface for this feature.
- Teachers can now select a key and a chord progression to generate chords, and then add them to a persistent display.
- A new `ClassroomDisplay` component has been created to render the selected chords.
- The instrument (guitar or piano) can be toggled for all displayed chords.