### PR TITLE
Fix: Resolve NodeJS namespace build error and other issues

### DIFF
--- a/src/components/classroom/ClassroomDisplay.tsx
+++ b/src/components/classroom/ClassroomDisplay.tsx
@@ -32,7 +32,6 @@ const ClassroomDisplay: React.FC<ClassroomDisplayProps> = ({ displayedChords, in
           )
         })}
       </div>
-    </div>
   )
 }
 

--- a/src/components/learning-path/LearningPathway.tsx
+++ b/src/components/learning-path/LearningPathway.tsx
@@ -6,7 +6,7 @@ import RhythmExercise from './exercises/RhythmExercise'
 import ChordSwitchingExercise from './exercises/ChordSwitchingExercise'
 import TheoryQuiz from './quizzes/TheoryQuiz'
 import AdvancedTechniqueExercise from './exercises/AdvancedTechniqueExercise'
-import CreatorMode from './CreatorMode'
+// import CreatorMode from './CreatorMode'
 
 const lessonComponents: Record<string, () => React.ReactElement> = {
   '1-e1': () => <NameTheNoteQuiz />,
@@ -27,7 +27,7 @@ const lessonComponents: Record<string, () => React.ReactElement> = {
     />
   ),
   '5-s1': () => <AdvancedTechniqueExercise />,
-  '6-k1': () => <CreatorMode />,
+  // '6-k1': () => <CreatorMode />,
 }
 
 const LearningPathway = () => {

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
-import Soundfont, { InstrumentPlayer } from 'soundfont-player';
+import Soundfont from 'soundfont-player';
 
 // Guitar string base notes (standard tuning)
 const GUITAR_STRING_NOTES = ['E2', 'A2', 'D3', 'G3', 'B3', 'E4'];
 
 const useAudio = () => {
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
-  const guitarInstrument = useRef<InstrumentPlayer | null>(null);
+  const guitarInstrument = useRef<any | null>(null);
   const isInitialized = useRef(false);
 
   const NOTE_FREQUENCIES: Record<string, number> = {

--- a/src/hooks/usePracticeStatistics.ts
+++ b/src/hooks/usePracticeStatistics.ts
@@ -10,8 +10,8 @@ const usePracticeStatistics = () => {
 
   const [isChallengeActive, setIsChallengeActive] = useState(false);
   const [challengeTime, setChallengeTime] = useState(0);
-  const challengeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const practiceTimeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const challengeIntervalRef = useRef<ReturnType<typeof window.setInterval> | null>(null);
+  const practiceTimeIntervalRef = useRef<ReturnType<typeof window.setInterval> | null>(null);
 
   useEffect(() => {
     const storedStats = localStorage.getItem('practiceStats');
@@ -46,7 +46,7 @@ const usePracticeStatistics = () => {
     if (practiceTimeIntervalRef.current) {
       clearInterval(practiceTimeIntervalRef.current);
     }
-    practiceTimeIntervalRef.current = setInterval(() => {
+    practiceTimeIntervalRef.current = window.setInterval(() => {
       setTotalPracticeTime(prevTime => prevTime + 1000);
     }, 1000);
   }, []);
@@ -80,7 +80,7 @@ const usePracticeStatistics = () => {
       clearInterval(challengeIntervalRef.current);
     }
     const startTime = Date.now();
-    challengeIntervalRef.current = setInterval(() => {
+    challengeIntervalRef.current = window.setInterval(() => {
       setChallengeTime(Date.now() - startTime);
     }, 10);
     startPracticeSession();


### PR DESCRIPTION
This commit resolves a build error caused by the TypeScript compiler's inability to find the `NodeJS` namespace. The primary fix involves explicitly using `window.setInterval` instead of `setInterval` in `src/hooks/usePracticeStatistics.ts` to clarify that the browser's implementation is being used.

During the build process, several other pre-existing errors were discovered in the codebase. These errors were also fixed to ensure a successful build:

- Fixed a syntax error in `src/components/classroom/ClassroomDisplay.tsx` by removing an extra closing `</div>` tag.
- Commented out a non-existent `CreatorMode` component in `src/components/learning-path/LearningPathway.tsx` to resolve an import error.
- Corrected an incorrect type import in `src/hooks/useAudio.ts` by removing the non-existent `InstrumentPlayer` type and using `any` as a temporary workaround.

These additional fixes were necessary to produce a working build, which was the user's primary goal.