### PR TITLE
Fix syntax error in ClassroomDisplay component

### DIFF
--- a/src/components/classroom/ClassroomDisplay.tsx
+++ b/src/components/classroom/ClassroomDisplay.tsx
@@ -32,7 +32,6 @@ const ClassroomDisplay: React.FC<ClassroomDisplayProps> = ({ displayedChords, in
           )
         })}
       </div>
-    </div>
   )
 }
 


### PR DESCRIPTION
Removes an extra closing `</div>` tag that was causing a build failure. The error messages indicated a parsing issue with the JSX, and this change corrects the tag imbalance.