### PR TITLE
Add audio playback to chord progression builder

### DIFF
--- a/src/components/chord-builder/ChordProgressionBuilder.tsx
+++ b/src/components/chord-builder/ChordProgressionBuilder.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import useAudio from '../../hooks/useAudio';
 
 interface Chord {
   id: string;
@@ -13,8 +14,46 @@ const ChordProgressionBuilder = () => {
     { id: '3', name: 'Am', key: 'A' },
     { id: '4', name: 'F', key: 'F' },
   ]);
-  
+
   const [selectedKey, setSelectedKey] = useState('C');
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const { initAudio, playChord } = useAudio();
+
+  useEffect(() => {
+    initAudio();
+  }, [initAudio]);
+
+  const NOTE_SEQUENCE = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+  const chordToNotes = (name: string): string[] => {
+    const isMinor = name.endsWith('m');
+    const root = isMinor ? name.slice(0, -1) : name;
+    const rootIndex = NOTE_SEQUENCE.indexOf(root);
+    if (rootIndex === -1) return [];
+
+    const thirdIndex = (rootIndex + (isMinor ? 3 : 4)) % 12;
+    const fifthIndex = (rootIndex + 7) % 12;
+
+    return [
+      `${root}4`,
+      `${NOTE_SEQUENCE[thirdIndex]}4`,
+      `${NOTE_SEQUENCE[fifthIndex]}4`,
+    ];
+  };
+
+  const handlePlay = async () => {
+    initAudio();
+    setIsPlaying(true);
+    for (const chord of chords) {
+      const notes = chordToNotes(chord.name);
+      if (notes.length > 0) {
+        playChord(notes, 0.8);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    setIsPlaying(false);
+  };
   
   const addChord = (chordName: string) => {
     const newChord = {
@@ -95,9 +134,11 @@ const ChordProgressionBuilder = () => {
           Clear All
         </button>
         <button
-          className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors"
+          onClick={handlePlay}
+          disabled={isPlaying}
+          className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          Play Progression
+          {isPlaying ? 'Playing...' : 'Play Progression'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- hook up `useAudio` in `ChordProgressionBuilder`
- add sequential chord playback with basic major/minor note mapping
- disable play button during playback

## Testing
- `npm test`
- `npm run lint` *(fails: Promises must be awaited; Unsafe call of a(n) `any` typed value; Unsafe member access .play on an `any` value; Unsafe assignment of an `any` value; Unsafe argument of type `any` assigned to a parameter of type `SetStateAction<number>`; Unsafe member access .totalPracticeTime on an `any` value; Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator; Unsafe member access .chordsPlayed on an `any` value; Unsafe argument of type `any` assigned to a parameter of type `SetStateAction<number | null>`)*

------
https://chatgpt.com/codex/tasks/task_e_68af33509cc08332b5331da6caccbdbb