### PR TITLE
Add teacher dashboard with student progress tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ChordWheel from './components/ChordWheel'
 import { useTheme } from './contexts/ThemeContext'
 import ScrollingPractice from './components/practice-mode/ScrollingPractice'
 import ClassroomMode from './components/classroom/ClassroomMode'
+import TeacherDashboard from './components/classroom/TeacherDashboard'
 // --- MERGED IMPORTS (from both branches) ---
 import { useUserProfile } from './contexts/UserProfileContext'
 import OnboardingFlow from './components/onboarding/OnboardingFlow'
@@ -173,6 +174,7 @@ function App() {
             <Route path="/wheel" element={<ChordWheel />} />
             <Route path="/metronome" element={<Metronome />} />
             <Route path="/classroom" element={<ClassroomMode />} />
+            <Route path="/classroom/dashboard" element={<TeacherDashboard />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/classroom/ClassroomMode.tsx
+++ b/src/components/classroom/ClassroomMode.tsx
@@ -3,6 +3,7 @@ import { getDiatonicChords } from '../../utils/music-theory'
 import GuitarDiagram from '../diagrams/GuitarDiagram'
 import PianoDiagram from '../diagrams/PianoDiagram'
 import ClassroomDisplay from '../classroom/ClassroomDisplay'
+import { useNavigate } from 'react-router-dom'
 
 const keys = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'Db', 'Ab', 'Eb', 'Bb', 'F']
 const progressions = ['I–V–vi–IV', 'vi–IV–I–V', 'ii–V–I', 'I–vi–IV–V']
@@ -36,6 +37,7 @@ const ClassroomMode: React.FC = () => {
   const [selectedProgression, setSelectedProgression] = useState('I–V–vi–IV')
   const [instrument, setInstrument] = useState<'guitar' | 'piano'>('guitar')
   const [displayedChords, setDisplayedChords] = useState<string[]>([])
+  const navigate = useNavigate()
 
   const generatedChords = useMemo(() => {
     const diatonic = getDiatonicChords(selectedKey)
@@ -100,6 +102,14 @@ const ClassroomMode: React.FC = () => {
             className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
           >
             Add to Display
+          </button>
+        </div>
+        <div>
+          <button
+            onClick={() => navigate('/classroom/dashboard')}
+            className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors"
+          >
+            View Progress
           </button>
         </div>
       </div>

--- a/src/components/classroom/TeacherDashboard.tsx
+++ b/src/components/classroom/TeacherDashboard.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import usePracticeStatistics from '../../hooks/usePracticeStatistics';
+import { useUserProfile } from '../../contexts/UserProfileContext';
+
+interface StudentStats {
+  name: string;
+  totalPracticeTime: number;
+  chordsPlayed: number;
+  currentLevel: string;
+}
+
+const TeacherDashboard: React.FC = () => {
+  const { totalPracticeTime, chordsPlayed } = usePracticeStatistics();
+  const { profile } = useUserProfile();
+  const [students, setStudents] = useState<StudentStats[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('studentPracticeStats');
+    const data: Record<string, StudentStats> = stored ? JSON.parse(stored) : {};
+
+    data[profile.name] = {
+      name: profile.name,
+      totalPracticeTime,
+      chordsPlayed,
+      currentLevel: profile.confidenceLevel,
+    };
+
+    localStorage.setItem('studentPracticeStats', JSON.stringify(data));
+    setStudents(Object.values(data));
+  }, [totalPracticeTime, chordsPlayed, profile]);
+
+  const formatTime = (ms: number) => {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}m ${seconds}s`;
+  };
+
+  const exportCSV = () => {
+    const header = 'Name,Time Practiced (minutes),Chords Played,Current Level\n';
+    const rows = students
+      .map(s => `${s.name},${(s.totalPracticeTime / 60000).toFixed(2)},${s.chordsPlayed},${s.currentLevel}`)
+      .join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'practice-stats.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-4">Student Progress</h3>
+      <table className="w-full mb-4">
+        <thead>
+          <tr className="text-left text-gray-700 dark:text-gray-200">
+            <th className="pb-2">Student</th>
+            <th className="pb-2">Time Practiced</th>
+            <th className="pb-2">Chords Played</th>
+            <th className="pb-2">Current Level</th>
+          </tr>
+        </thead>
+        <tbody>
+          {students.map(student => (
+            <tr key={student.name} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="py-2 text-gray-900 dark:text-gray-100">{student.name}</td>
+              <td className="py-2 text-gray-900 dark:text-gray-100">{formatTime(student.totalPracticeTime)}</td>
+              <td className="py-2 text-gray-900 dark:text-gray-100">{student.chordsPlayed}</td>
+              <td className="py-2 text-gray-900 dark:text-gray-100 capitalize">{student.currentLevel}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        onClick={exportCSV}
+        className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+      >
+        Export CSV
+      </button>
+    </div>
+  );
+};
+
+export default TeacherDashboard;
+


### PR DESCRIPTION
## Summary
- add `TeacherDashboard` to display student practice stats and export them to CSV
- link classroom creator mode to the new dashboard
- register dashboard route in app routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af37b788148332ab5f11449088923f