### PR TITLE
Expand layout width for broader pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
         {/* --- MERGED JSX (from main branch) --- */}
         <AchievementToast />
         <header className="bg-white dark:bg-gray-900/80 dark:border-b dark:border-gray-700 shadow-sm relative backdrop-blur-lg">
-          <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div className="w-full mx-auto px-4 md:px-8 py-3 flex items-center justify-between">
             <div className="flex items-center gap-4">
               <span className="font-extrabold text-xl text-gray-900 dark:text-gray-100">
                 Chord Lab
@@ -163,7 +163,7 @@ function App() {
           )}
         </header>
 
-        <main className="max-w-6xl mx-auto px-4 py-6">
+        <main className="w-full mx-auto px-4 md:px-8 py-6">
           <Routes>
             <Route path="/" element={<Dashboard />} />
             <Route path="/create" element={<ChordProgressionBuilder />} />

--- a/src/components/ChordWheel.tsx
+++ b/src/components/ChordWheel.tsx
@@ -84,7 +84,7 @@ export default function ChordWheel() {
   }, [activeKey])
 
   return (
-    <div className="bg-white dark:bg-gray-800/50 rounded-2xl shadow-lg p-4 max-w-4xl mx-auto">
+    <div className="w-full bg-white dark:bg-gray-800/50 rounded-2xl shadow-lg p-4 md:p-8">
       <div className="flex items-center justify-between gap-4 mb-2">
         <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">Chord Wheel</h2>
         <div className="flex items-center gap-2">
@@ -106,7 +106,7 @@ export default function ChordWheel() {
         </div>
       </div>
       <div className="w-full flex justify-center">
-        <svg viewBox={`0 0 ${size} ${size}`} className="w-full max-w-[720px] h-auto">
+        <svg viewBox={`0 0 ${size} ${size}`} className="w-full h-auto">
           <defs>
             <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
               <feGaussianBlur stdDeviation="4" result="blur" />

--- a/src/components/diagrams/GuitarDiagram.tsx
+++ b/src/components/diagrams/GuitarDiagram.tsx
@@ -63,8 +63,8 @@ const FretboardWrap = ({ children }: { children: React.ReactNode }) => (
   <div
     className="fretboard-wrap"
     style={{
-      width: '520px',
-      maxWidth: '100%',
+      width: '100%',
+      maxWidth: '700px',
       margin: '0 auto',
       background: '#fff',
       borderRadius: '14px',

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -222,7 +222,7 @@ const PracticeMode: FC = () => {
   }, [keyCenter]);
 
   return (
-    <div className="bg-white dark:bg-gray-800/50 rounded-xl shadow-lg p-6">
+    <div className="w-full bg-white dark:bg-gray-800/50 rounded-xl shadow-lg p-6">
       <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">Practice Mode</h2>
       {keyCenter && (
         <div className="mb-4 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/30">


### PR DESCRIPTION
## Summary
- Expand header and main containers to full width with responsive padding
- Allow practice and chord wheel pages to stretch with wider layouts
- Relax fixed diagram widths for better scaling

## Testing
- `npm run lint` (fails: Promises must be awaited and other existing lint errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af39ff1c008332b969cf727a1ca076