### PR TITLE
feat: track guitar soundfont load state

### DIFF
--- a/src/components/practice-mode/PracticeMetronomeControls.tsx
+++ b/src/components/practice-mode/PracticeMetronomeControls.tsx
@@ -7,6 +7,7 @@ interface PracticeMetronomeControlsProps {
   toggleMetronome: () => void;
   handleStrum: () => void;
   nextChord: () => void;
+  disableStrum?: boolean;
 }
 
 const PracticeMetronomeControls: FC<PracticeMetronomeControlsProps> = ({
@@ -16,6 +17,7 @@ const PracticeMetronomeControls: FC<PracticeMetronomeControlsProps> = ({
   toggleMetronome,
   handleStrum,
   nextChord,
+  disableStrum = false,
 }) => {
   return (
     <div className="flex flex-col items-end gap-2">
@@ -47,7 +49,8 @@ const PracticeMetronomeControls: FC<PracticeMetronomeControlsProps> = ({
         </button>
         <button
           onClick={handleStrum}
-          className="px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white"
+          disabled={disableStrum}
+          className="px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"
           title="Play a quick strum"
         >
           Strum

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -136,7 +136,7 @@ const PracticeMode: FC = () => {
   const location = useLocation();
   const practicedChordsRef = useRef<Set<string>>(new Set());
   const [keyCenter, setKeyCenter] = useState<MajorKey | null>(null);
-  const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
+  const { playChord, playGuitarNote, initAudio, fretToNote, guitarLoaded } = useAudio();
 
   // Read URL params (?key=, ?chord=) and set initial state
   useEffect(() => {
@@ -302,6 +302,7 @@ const PracticeMode: FC = () => {
               toggleMetronome={toggleMetronome}
               handleStrum={handleStrum}
               nextChord={nextChord}
+              disableStrum={selectedInstrument === 'guitar' && !guitarLoaded}
             />
           </div>
 
@@ -321,6 +322,10 @@ const PracticeMode: FC = () => {
             playPianoNote={note => playChord([note], 0.5, 'piano')}
             initAudio={initAudio}
           />
+
+          {selectedInstrument === 'guitar' && !guitarLoaded && (
+            <p className="text-gray-500 text-sm mt-2">Loading sounds...</p>
+          )}
 
           {showTips && (
             <div className="bg-blue-50 dark:bg-blue-900/30 border-l-4 border-blue-500 p-4 rounded">


### PR DESCRIPTION
## Summary
- track when the guitar soundfont finishes loading in `useAudio`
- guard guitar playback with early return warnings until sounds load
- surface guitar loading state to UI and disable guitar strum button while loading

## Testing
- `npm test`
- `npm run lint` *(fails: Promises must be awaited, Unsafe call of a(n) `any` typed value, Unsafe member access .play on an `any` value, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68af3b0aafd88332b8f363c034994fa0