### PR TITLE
Add starter lessons for piano and guitar

### DIFF
--- a/src/components/learning-path/LearningPathway.tsx
+++ b/src/components/learning-path/LearningPathway.tsx
@@ -7,8 +7,12 @@ import ChordSwitchingExercise from './exercises/ChordSwitchingExercise'
 import TheoryQuiz from './quizzes/TheoryQuiz'
 import AdvancedTechniqueExercise from './exercises/AdvancedTechniqueExercise'
 import ClassroomMode from '../classroom/ClassroomMode'
+import PianoBasicsLesson from './lessons/PianoBasicsLesson'
+import GuitarEssentialsLesson from './lessons/GuitarEssentialsLesson'
 
 const lessonComponents: Record<string, () => React.ReactElement> = {
+  '1-pb': () => <PianoBasicsLesson />,
+  '1-ge': () => <GuitarEssentialsLesson />,
   '1-e1': () => <NameTheNoteQuiz />,
   '1-s2': () => <RhythmExercise />,
   '2-s1': () => <ChordSwitchingExercise progression={['C', 'F']} />,

--- a/src/components/learning-path/lessons/GuitarEssentialsLesson.tsx
+++ b/src/components/learning-path/lessons/GuitarEssentialsLesson.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const GuitarEssentialsLesson: React.FC = () => (
+  <div className="text-gray-700 dark:text-gray-300">
+    <p className="mb-2">
+      Review these guitar fundamentals:
+    </p>
+    <ul className="list-disc list-inside space-y-1">
+      <li>String names from low to high: E–A–D–G–B–E.</li>
+      <li>Number your fretting fingers 1–4 (index to pinky).</li>
+      <li>Practice gentle fretting and a relaxed strum or pick.</li>
+    </ul>
+  </div>
+)
+
+export default GuitarEssentialsLesson

--- a/src/components/learning-path/lessons/PianoBasicsLesson.tsx
+++ b/src/components/learning-path/lessons/PianoBasicsLesson.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const PianoBasicsLesson: React.FC = () => (
+  <div className="text-gray-700 dark:text-gray-300">
+    <p className="mb-2">
+      Get comfortable at the piano before moving on:
+    </p>
+    <ul className="list-disc list-inside space-y-1">
+      <li>Find middle C and the repeating pattern of white keys.</li>
+      <li>Use proper seating posture with relaxed shoulders.</li>
+      <li>Memorize finger numbers 1–5 (thumb to pinky).</li>
+    </ul>
+  </div>
+)
+
+export default PianoBasicsLesson

--- a/src/data/learning-path.ts
+++ b/src/data/learning-path.ts
@@ -25,6 +25,22 @@ export const learningPath: Level[] = [
     ],
     lessons: [
       {
+        id: '1-pb',
+        title: 'Piano Basics',
+        description:
+          'Explore the keyboard layout, proper seating posture, and finger numbers 1–5.',
+        completed: false,
+        type: 'knowledge',
+      },
+      {
+        id: '1-ge',
+        title: 'Guitar Essentials',
+        description:
+          'Learn string names E–A–D–G–B–E, tuning, and relaxed fretting technique.',
+        completed: false,
+        type: 'knowledge',
+      },
+      {
         id: '1-k1',
         title: 'Core Knowledge: Keyboard',
         description: 'Finger numbers 1–5 (thumb=1), white-key names A–G, middle C location.',


### PR DESCRIPTION
## Summary
- add Piano Basics and Guitar Essentials starter lessons to learning path data
- create lesson components and hook them into LearningPathway

## Testing
- `npm test` *(fails: Unable to find an element by [data-testid="current-chord-name"], PracticeMode tests etc.)*
- `npm run lint` *(fails: @typescript-eslint no-explicit-any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af41c8b22c8332929d221c395461e3