### PR TITLE
feat: centralize chord data

### DIFF
--- a/src/components/chord-builder/ChordProgressionBuilder.tsx
+++ b/src/components/chord-builder/ChordProgressionBuilder.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import useAudio from '../../hooks/useAudio';
+import { chords as chordData } from '../../data/chords';
 
 interface Chord {
   id: string;
@@ -33,29 +34,11 @@ const ChordProgressionBuilder = () => {
     localStorage.setItem('chordProgression', JSON.stringify(chords));
   }, [chords]);
 
-  const NOTE_SEQUENCE = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-
-  const chordToNotes = (name: string): string[] => {
-    const isMinor = name.endsWith('m');
-    const root = isMinor ? name.slice(0, -1) : name;
-    const rootIndex = NOTE_SEQUENCE.indexOf(root);
-    if (rootIndex === -1) return [];
-
-    const thirdIndex = (rootIndex + (isMinor ? 3 : 4)) % 12;
-    const fifthIndex = (rootIndex + 7) % 12;
-
-    return [
-      `${root}4`,
-      `${NOTE_SEQUENCE[thirdIndex]}4`,
-      `${NOTE_SEQUENCE[fifthIndex]}4`,
-    ];
-  };
-
   const handlePlay = async () => {
     initAudio();
     setIsPlaying(true);
     for (const chord of chords) {
-      const notes = chordToNotes(chord.name);
+      const notes = chordData[chord.name]?.pianoNotes ?? [];
       if (notes.length > 0) {
         playChord(notes, 0.8);
         await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/components/classroom/ClassroomDisplay.tsx
+++ b/src/components/classroom/ClassroomDisplay.tsx
@@ -1,23 +1,19 @@
 import React from 'react'
 import GuitarDiagram from '../diagrams/GuitarDiagram'
 import PianoDiagram from '../diagrams/PianoDiagram'
-
-interface ChordDefinition {
-  notes: string[];
-  guitarPositions: { string: number; fret: number }[];
-}
+import type { ChordDefinition } from '../../data/chords'
 
 interface ClassroomDisplayProps {
-  displayedChords: string[];
-  instrument: 'guitar' | 'piano';
-  chordData: Record<string, ChordDefinition>;
+  displayedChords: string[]
+  instrument: 'guitar' | 'piano'
+  chordData: Record<string, ChordDefinition>
 }
 
 const ClassroomDisplay: React.FC<ClassroomDisplayProps> = ({ displayedChords, instrument, chordData }) => {
   return (
     <div className={`grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mt-2`}>
       {displayedChords.map((chord, index) => {
-        const data = chordData[chord] ?? { notes: [], guitarPositions: [] }
+        const data = chordData[chord] ?? { pianoNotes: [], guitarPositions: [] }
         return (
           <div
             key={index}
@@ -26,7 +22,7 @@ const ClassroomDisplay: React.FC<ClassroomDisplayProps> = ({ displayedChords, in
             {instrument === 'guitar' ? (
               <GuitarDiagram chordName={chord} positions={data.guitarPositions} />
             ) : (
-              <PianoDiagram chordName={chord} notes={data.notes} />
+              <PianoDiagram chordName={chord} notes={data.pianoNotes} />
             )}
           </div>
         )

--- a/src/components/classroom/ClassroomMode.tsx
+++ b/src/components/classroom/ClassroomMode.tsx
@@ -3,6 +3,7 @@ import { getDiatonicChords } from '../../utils/music-theory'
 import GuitarDiagram from '../diagrams/GuitarDiagram'
 import PianoDiagram from '../diagrams/PianoDiagram'
 import ClassroomDisplay from '../classroom/ClassroomDisplay'
+import { chords as chordData, type ChordDefinition } from '../../data/chords'
 
 const keys = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'Db', 'Ab', 'Eb', 'Bb', 'F']
 const progressions = ['I–V–vi–IV', 'vi–IV–I–V', 'ii–V–I', 'I–vi–IV–V']
@@ -16,20 +17,7 @@ const numeralMap: Record<string, number> = {
   vii: 6,
 }
 
-interface ChordDefinition {
-  notes: string[];
-  guitarPositions: { string: number; fret: number }[];
-}
-
-const chordData: Record<string, ChordDefinition> = {
-  C: { notes: ['C4', 'E4', 'G4'], guitarPositions: [{ string: 2, fret: 1 }, { string: 4, fret: 2 }, { string: 5, fret: 3 }] },
-  G: { notes: ['G3', 'B3', 'D4'], guitarPositions: [{ string: 1, fret: 3 }, { string: 5, fret: 2 }, { string: 6, fret: 3 }] },
-  Am: { notes: ['A3', 'C4', 'E4'], guitarPositions: [{ string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 2 }] },
-  F: { notes: ['F3', 'A3', 'C4'], guitarPositions: [{ string: 1, fret: 1 }, { string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 3 }] },
-  D: { notes: ['D4', 'F#4', 'A4'], guitarPositions: [{ string: 1, fret: 2 }, { string: 2, fret: 3 }, { string: 3, fret: 2 }] },
-  Em: { notes: ['E3', 'G3', 'B3'], guitarPositions: [{ string: 4, fret: 2 }, { string: 5, fret: 2 }] },
-  // Add other chords as needed
-};
+// chordData imported from data/chords
 
 const ClassroomMode: React.FC = () => {
   const [selectedKey, setSelectedKey] = useState('C')
@@ -107,7 +95,7 @@ const ClassroomMode: React.FC = () => {
         <h4 className="font-bold text-gray-700 dark:text-gray-200">Generated Progression:</h4>
         <div className={`grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mt-2`}>
           {generatedChords.map((chord, index) => {
-            const data = chordData[chord] ?? { notes: [], guitarPositions: [] };
+            const data = chordData[chord] ?? { pianoNotes: [], guitarPositions: [] };
             return (
               <div
                 key={index}
@@ -116,7 +104,7 @@ const ClassroomMode: React.FC = () => {
                 {instrument === 'guitar' ? (
                   <GuitarDiagram chordName={chord} positions={data.guitarPositions} />
                 ) : (
-                  <PianoDiagram chordName={chord} notes={data.notes} />
+                  <PianoDiagram chordName={chord} notes={data.pianoNotes} />
                 )}
               </div>
             )

--- a/src/components/learning-path/exercises/AdvancedTechniqueExercise.tsx
+++ b/src/components/learning-path/exercises/AdvancedTechniqueExercise.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
-import PianoDiagram from '../../diagrams/PianoDiagram';
+import React, { useState } from 'react'
+import PianoDiagram from '../../diagrams/PianoDiagram'
+import { chords } from '../../../data/chords'
 
 const AdvancedTechniqueExercise: React.FC = () => {
-  const progression = ['C', 'G', 'Am', 'F'];
+  const progression: (keyof typeof chords)[] = ['C', 'G', 'Am', 'F']
   const [inversions, setInversions] = useState<Record<string, 0 | 1 | 2>>({
     C: 0,
     G: 0,
@@ -14,24 +15,17 @@ const AdvancedTechniqueExercise: React.FC = () => {
     setInversions((prev) => ({ ...prev, [chord]: inversion }));
   };
 
-  const chordNotes: Record<string, string[]> = {
-    C: ['C4', 'E4', 'G4'],
-    G: ['G3', 'B3', 'D4'],
-    Am: ['A3', 'C4', 'E4'],
-    F: ['F3', 'A3', 'C4'],
-  };
-
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
       <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-4">
         Advanced Technique: Inversions
       </h3>
       <div className="grid grid-cols-4 gap-4">
-        {progression.map((chord) => (
+        {progression.map(chord => (
           <div key={chord}>
             <PianoDiagram
               chordName={chord}
-              notes={chordNotes[chord]}
+              notes={chords[chord].pianoNotes}
               inversion={inversions[chord]}
             />
             <div className="mt-2 flex justify-center space-x-2">

--- a/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
+++ b/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
@@ -1,73 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import useMetronome from '../../../hooks/useMetronome'
 import GuitarDiagram from '../../diagrams/GuitarDiagram'
-
-type ChordName = 'C' | 'F' | 'G' | 'Am' | 'D' | 'Em'
-interface ChordData {
-  name: ChordName
-  guitarPositions: { string: number; fret: number }[]
-  guitarFingers: number[]
-}
-
-const chords: Record<ChordName, ChordData> = {
-  C: {
-    name: 'C',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
-    ],
-    guitarFingers: [1, 2, 3],
-  },
-  F: {
-    name: 'F',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
-    ],
-    guitarFingers: [1, 1, 2, 3],
-  },
-  G: {
-    name: 'G',
-    guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
-    ],
-    guitarFingers: [3, 2, 4],
-  },
-  Am: {
-    name: 'Am',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
-    ],
-    guitarFingers: [1, 2, 3],
-  },
-  D: {
-    name: 'D',
-    guitarPositions: [
-      { string: 1, fret: 2 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
-    ],
-    guitarFingers: [2, 3, 1],
-  },
-  Em: {
-    name: 'Em',
-    guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
-    ],
-    guitarFingers: [2, 3],
-  },
-}
+import { chords } from '../../../data/chords'
 
 interface ChordSwitchingExerciseProps {
-  progression: ChordName[]
+  progression: string[]
 }
 
 const ChordSwitchingExercise: React.FC<ChordSwitchingExerciseProps> = ({ progression }) => {
@@ -123,9 +60,9 @@ const ChordSwitchingExercise: React.FC<ChordSwitchingExerciseProps> = ({ progres
             }`}
           >
             <GuitarDiagram
-              chordName={chords[chordName].name}
-              positions={chords[chordName].guitarPositions}
-              fingers={chords[chordName].guitarFingers}
+              chordName={chordName}
+              positions={chords[chordName as keyof typeof chords].guitarPositions}
+              fingers={chords[chordName as keyof typeof chords].guitarFingers}
             />
           </div>
         ))}

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -9,6 +9,7 @@ import ChallengeMode from './ChallengeMode';
 import Statistics from './Statistics';
 import PracticeMetronomeControls from './PracticeMetronomeControls';
 import InstrumentPanel from './InstrumentPanel';
+import { chords as chordDictionary } from '../../data/chords';
 
 interface Chord {
   name: string;
@@ -35,72 +36,13 @@ const RELATIVE_MINORS: Record<MajorKey, string> = {
   F: 'Dm',
 };
 
-// Sample chord data
-const chords: Chord[] = [
-  // Majors
-  {
-    name: 'C',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['C4', 'E4', 'G4'],
-  },
-  {
-    name: 'G',
-    guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 2, fret: 0 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
-    ],
-    guitarFingers: [3, 0, 2, 4],
-    pianoNotes: ['G3', 'B3', 'D4'],
-  },
-  {
-    name: 'F',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
-    ],
-    guitarFingers: [1, 1, 2, 3],
-    pianoNotes: ['F3', 'A3', 'C4'],
-  },
-  // Minors
-  {
-    name: 'Am',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['A3', 'C4', 'E4'],
-  },
-  {
-    name: 'Em',
-    guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
-    ],
-    guitarFingers: [2, 3],
-    pianoNotes: ['E3', 'G3', 'B3'],
-  },
-  {
-    name: 'Dm',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
-    ],
-    guitarFingers: [1, 3, 2],
-    pianoNotes: ['D4', 'F4', 'A4'],
-  },
-];
+// Build chord list from dictionary
+const chords: Chord[] = Object.entries(chordDictionary).map(([name, data]) => ({
+  name,
+  guitarPositions: data.guitarPositions,
+  guitarFingers: data.guitarFingers ?? [],
+  pianoNotes: data.pianoNotes,
+}));
 
 function getDiatonicForKey(keyCenter: MajorKey) {
   const idx = MAJORS_ORDER.indexOf(keyCenter);

--- a/src/data/chords.ts
+++ b/src/data/chords.ts
@@ -1,0 +1,267 @@
+export interface FretPosition {
+  string: number;
+  fret: number;
+}
+
+export interface ChordDefinition {
+  pianoNotes: string[];
+  guitarPositions: FretPosition[];
+  guitarFingers?: number[];
+}
+
+export const chords: Record<string, ChordDefinition> = {
+  C: {
+    pianoNotes: ['C4', 'E4', 'G4'],
+    guitarPositions: [
+      { string: 2, fret: 1 },
+      { string: 4, fret: 2 },
+      { string: 5, fret: 3 },
+    ],
+    guitarFingers: [1, 2, 3],
+  },
+  G: {
+    pianoNotes: ['G3', 'B3', 'D4'],
+    guitarPositions: [
+      { string: 1, fret: 3 },
+      { string: 5, fret: 2 },
+      { string: 6, fret: 3 },
+    ],
+    guitarFingers: [3, 2, 4],
+  },
+  D: {
+    pianoNotes: ['D4', 'F#4', 'A4'],
+    guitarPositions: [
+      { string: 1, fret: 2 },
+      { string: 2, fret: 3 },
+      { string: 3, fret: 2 },
+    ],
+    guitarFingers: [2, 3, 1],
+  },
+  A: {
+    pianoNotes: ['A3', 'C#4', 'E4'],
+    guitarPositions: [
+      { string: 4, fret: 2 },
+      { string: 3, fret: 2 },
+      { string: 2, fret: 2 },
+    ],
+    guitarFingers: [1, 2, 3],
+  },
+  E: {
+    pianoNotes: ['E3', 'G#3', 'B3'],
+    guitarPositions: [
+      { string: 5, fret: 2 },
+      { string: 4, fret: 2 },
+      { string: 3, fret: 1 },
+    ],
+    guitarFingers: [2, 3, 1],
+  },
+  F: {
+    pianoNotes: ['F3', 'A3', 'C4'],
+    guitarPositions: [
+      { string: 1, fret: 1 },
+      { string: 2, fret: 1 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 3 },
+    ],
+    guitarFingers: [1, 1, 2, 3],
+  },
+  Bb: {
+    pianoNotes: ['Bb3', 'D4', 'F4'],
+    guitarPositions: [
+      { string: 5, fret: 1 },
+      { string: 4, fret: 3 },
+      { string: 3, fret: 3 },
+      { string: 2, fret: 3 },
+      { string: 1, fret: 1 },
+    ],
+    guitarFingers: [1, 3, 4, 4, 1],
+  },
+  Eb: {
+    pianoNotes: ['Eb4', 'G4', 'Bb4'],
+    guitarPositions: [
+      { string: 5, fret: 6 },
+      { string: 4, fret: 8 },
+      { string: 3, fret: 8 },
+      { string: 2, fret: 8 },
+      { string: 1, fret: 6 },
+    ],
+    guitarFingers: [1, 3, 4, 4, 1],
+  },
+  Ab: {
+    pianoNotes: ['Ab3', 'C4', 'Eb4'],
+    guitarPositions: [
+      { string: 6, fret: 4 },
+      { string: 5, fret: 6 },
+      { string: 4, fret: 6 },
+      { string: 3, fret: 5 },
+      { string: 2, fret: 4 },
+      { string: 1, fret: 4 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1, 1],
+  },
+  Db: {
+    pianoNotes: ['Db4', 'F4', 'Ab4'],
+    guitarPositions: [
+      { string: 5, fret: 4 },
+      { string: 4, fret: 6 },
+      { string: 3, fret: 6 },
+      { string: 2, fret: 6 },
+      { string: 1, fret: 4 },
+    ],
+    guitarFingers: [1, 3, 4, 4, 1],
+  },
+  'F#': {
+    pianoNotes: ['F#3', 'A#3', 'C#4'],
+    guitarPositions: [
+      { string: 6, fret: 2 },
+      { string: 5, fret: 4 },
+      { string: 4, fret: 4 },
+      { string: 3, fret: 3 },
+      { string: 2, fret: 2 },
+      { string: 1, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1, 1],
+  },
+  B: {
+    pianoNotes: ['B3', 'D#4', 'F#4'],
+    guitarPositions: [
+      { string: 5, fret: 2 },
+      { string: 4, fret: 4 },
+      { string: 3, fret: 4 },
+      { string: 2, fret: 4 },
+      { string: 1, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 4, 4, 1],
+  },
+  Am: {
+    pianoNotes: ['A3', 'C4', 'E4'],
+    guitarPositions: [
+      { string: 2, fret: 1 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 2 },
+    ],
+    guitarFingers: [1, 2, 3],
+  },
+  Em: {
+    pianoNotes: ['E3', 'G3', 'B3'],
+    guitarPositions: [
+      { string: 4, fret: 2 },
+      { string: 5, fret: 2 },
+    ],
+    guitarFingers: [2, 3],
+  },
+  Dm: {
+    pianoNotes: ['D4', 'F4', 'A4'],
+    guitarPositions: [
+      { string: 1, fret: 1 },
+      { string: 2, fret: 3 },
+      { string: 3, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 2],
+  },
+  Bm: {
+    pianoNotes: ['B3', 'D4', 'F#4'],
+    guitarPositions: [
+      { string: 5, fret: 2 },
+      { string: 4, fret: 4 },
+      { string: 3, fret: 4 },
+      { string: 2, fret: 3 },
+      { string: 1, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1],
+  },
+  'F#m': {
+    pianoNotes: ['F#3', 'A3', 'C#4'],
+    guitarPositions: [
+      { string: 6, fret: 2 },
+      { string: 5, fret: 4 },
+      { string: 4, fret: 4 },
+      { string: 3, fret: 2 },
+      { string: 2, fret: 2 },
+      { string: 1, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1, 1],
+  },
+  'C#m': {
+    pianoNotes: ['C#4', 'E4', 'G#4'],
+    guitarPositions: [
+      { string: 5, fret: 4 },
+      { string: 4, fret: 6 },
+      { string: 3, fret: 6 },
+      { string: 2, fret: 5 },
+      { string: 1, fret: 4 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1],
+  },
+  'G#m': {
+    pianoNotes: ['G#3', 'B3', 'D#4'],
+    guitarPositions: [
+      { string: 6, fret: 4 },
+      { string: 5, fret: 6 },
+      { string: 4, fret: 6 },
+      { string: 3, fret: 4 },
+      { string: 2, fret: 4 },
+      { string: 1, fret: 4 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1, 1],
+  },
+  'D#m': {
+    pianoNotes: ['D#4', 'F#4', 'A#4'],
+    guitarPositions: [
+      { string: 5, fret: 6 },
+      { string: 4, fret: 8 },
+      { string: 3, fret: 8 },
+      { string: 2, fret: 7 },
+      { string: 1, fret: 6 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1],
+  },
+  Bbm: {
+    pianoNotes: ['Bb3', 'Db4', 'F4'],
+    guitarPositions: [
+      { string: 5, fret: 1 },
+      { string: 4, fret: 3 },
+      { string: 3, fret: 3 },
+      { string: 2, fret: 2 },
+      { string: 1, fret: 1 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1],
+  },
+  Fm: {
+    pianoNotes: ['F3', 'Ab3', 'C4'],
+    guitarPositions: [
+      { string: 6, fret: 1 },
+      { string: 5, fret: 3 },
+      { string: 4, fret: 3 },
+      { string: 3, fret: 1 },
+      { string: 2, fret: 1 },
+      { string: 1, fret: 1 },
+    ],
+    guitarFingers: [1, 3, 4, 1, 1, 1],
+  },
+  Cm: {
+    pianoNotes: ['C4', 'Eb4', 'G4'],
+    guitarPositions: [
+      { string: 5, fret: 3 },
+      { string: 4, fret: 5 },
+      { string: 3, fret: 5 },
+      { string: 2, fret: 4 },
+      { string: 1, fret: 3 },
+    ],
+    guitarFingers: [1, 3, 4, 2, 1],
+  },
+  Gm: {
+    pianoNotes: ['G3', 'Bb3', 'D4'],
+    guitarPositions: [
+      { string: 6, fret: 3 },
+      { string: 5, fret: 5 },
+      { string: 4, fret: 5 },
+      { string: 3, fret: 3 },
+      { string: 2, fret: 3 },
+      { string: 1, fret: 3 },
+    ],
+    guitarFingers: [1, 3, 4, 1, 1, 1],
+  },
+};
+
+export type ChordName = keyof typeof chords;


### PR DESCRIPTION
## Summary
- add shared chord dictionary with piano notes and guitar positions
- load chord definitions from dictionary across practice, classroom, and lessons
- simplify progression builder to play chords from dictionary data

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: @typescript-eslint/no-misused-promises, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af3af440608332878e3e63ca517ae0