### PR TITLE
Add music trivia quick quiz

### DIFF
--- a/src/components/quick-quiz/MusicTriviaQuickQuiz.tsx
+++ b/src/components/quick-quiz/MusicTriviaQuickQuiz.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import QuickQuiz from './QuickQuiz';
+import musicTriviaQuestions from '../../data/musicTriviaQuestions';
+
+const MusicTriviaQuickQuiz: React.FC = () => {
+  return <QuickQuiz questions={musicTriviaQuestions} numberOfQuestions={10} />;
+};
+
+export default MusicTriviaQuickQuiz;

--- a/src/components/quick-quiz/QuickQuiz.tsx
+++ b/src/components/quick-quiz/QuickQuiz.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+
+export interface QuickQuizQuestion {
+  question: string;
+  answers: string[];
+  correctAnswer: number; // index in answers
+}
+
+interface QuickQuizProps {
+  questions: QuickQuizQuestion[];
+  numberOfQuestions?: number;
+}
+
+const QuickQuiz: React.FC<QuickQuizProps> = ({ questions, numberOfQuestions = 10 }) => {
+  const [quizQuestions, setQuizQuestions] = useState<QuickQuizQuestion[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [score, setScore] = useState(0);
+  const [finished, setFinished] = useState(false);
+
+  useEffect(() => {
+    const shuffled = [...questions]
+      .sort(() => Math.random() - 0.5)
+      .slice(0, numberOfQuestions);
+    setQuizQuestions(shuffled);
+  }, [questions, numberOfQuestions]);
+
+  const currentQuestion = quizQuestions[currentIndex];
+
+  const handleAnswer = (index: number) => {
+    if (selected !== null) return;
+    setSelected(index);
+    if (index === currentQuestion.correctAnswer) {
+      setScore((s) => s + 1);
+    }
+    setTimeout(() => {
+      const next = currentIndex + 1;
+      if (next < quizQuestions.length) {
+        setCurrentIndex(next);
+        setSelected(null);
+      } else {
+        setFinished(true);
+      }
+    }, 1000);
+  };
+
+  if (!currentQuestion) {
+    return <div />;
+  }
+
+  if (finished) {
+    return (
+      <div className="text-center">
+        <p className="text-2xl font-bold mb-4">Quiz Complete!</p>
+        <p className="text-lg">Score: {score} / {quizQuestions.length}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <h3 className="text-xl font-semibold mb-6 text-center">{currentQuestion.question}</h3>
+      <div className="grid grid-cols-1 gap-4 w-full max-w-md">
+        {currentQuestion.answers.map((answer, i) => (
+          <button
+            key={i}
+            onClick={() => handleAnswer(i)}
+            disabled={selected !== null}
+            className={`py-4 px-6 rounded-lg text-lg font-medium transition-colors ${
+              selected === null
+                ? 'bg-blue-100 hover:bg-blue-200'
+                : i === currentQuestion.correctAnswer
+                ? 'bg-green-500 text-white'
+                : selected === i
+                ? 'bg-red-500 text-white'
+                : 'bg-blue-100 opacity-50'
+            }`}
+          >
+            {answer}
+          </button>
+        ))}
+      </div>
+      <p className="mt-4 text-sm text-gray-600">
+        {currentIndex + 1} / {quizQuestions.length}
+      </p>
+    </div>
+  );
+};
+
+export default QuickQuiz;

--- a/src/data/musicTriviaQuestions.ts
+++ b/src/data/musicTriviaQuestions.ts
@@ -1,0 +1,135 @@
+export interface MusicTriviaQuestion {
+  question: string;
+  answers: string[];
+  correctAnswer: number; // index in answers
+}
+
+const musicTriviaQuestions: MusicTriviaQuestion[] = [
+  {
+    question: 'Which instrument family does the clarinet belong to?',
+    answers: ['Woodwind', 'Brass', 'Strings', 'Percussion'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Who is known as the King of Pop?',
+    answers: ['Michael Jackson', 'Elvis Presley', 'Prince', 'Justin Bieber'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which composer became deaf later in life?',
+    answers: ['Mozart', 'Beethoven', 'Bach', 'Chopin'],
+    correctAnswer: 1,
+  },
+  {
+    question: 'What symbol raises a note by a half step?',
+    answers: ['Sharp', 'Flat', 'Natural', 'Clef'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'How many keys are on a standard full-size piano?',
+    answers: ['88', '76', '61', '100'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which rock band wrote "Bohemian Rhapsody"?',
+    answers: ['Queen', 'The Beatles', 'Led Zeppelin', 'Pink Floyd'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What is the highest female voice type?',
+    answers: ['Alto', 'Soprano', 'Mezzo-soprano', 'Contralto'],
+    correctAnswer: 1,
+  },
+  {
+    question: 'What tempo marking means "slowly"?',
+    answers: ['Adagio', 'Allegro', 'Presto', 'Moderato'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which instrument has 47 strings and seven pedals?',
+    answers: ['Harp', 'Harpsichord', 'Piano', 'Lute'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which note gets the beat in 3/4 time?',
+    answers: ['Quarter note', 'Half note', 'Eighth note', 'Whole note'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Who composed "The Four Seasons"?',
+    answers: ['Vivaldi', 'Handel', 'Tchaikovsky', 'Debussy'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What is the relative minor of C major?',
+    answers: ['A minor', 'E minor', 'D minor', 'F minor'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What is the term for gradually getting louder?',
+    answers: ['Crescendo', 'Diminuendo', 'Staccato', 'Legato'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which jazz musician was nicknamed "Satchmo"?',
+    answers: ['Louis Armstrong', 'Charlie Parker', 'Duke Ellington', 'Miles Davis'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which scale consists of five notes per octave?',
+    answers: ['Pentatonic', 'Chromatic', 'Whole tone', 'Dorian'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What is the Italian term for "very fast"?',
+    answers: ['Presto', 'Largo', 'Andante', 'Vivace'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which instrument is part of the brass family?',
+    answers: ['Trumpet', 'Clarinet', 'Oboe', 'Violin'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which song is the best-selling single of all time?',
+    answers: ['White Christmas', 'Candle in the Wind', 'Shape of You', 'Thriller'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What is the standard tuning of a guitar from lowest to highest?',
+    answers: ['EADGBE', 'GCFADG', 'DADGBE', 'EADFBE'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which composer wrote the "Moonlight Sonata"?',
+    answers: ['Beethoven', 'Mozart', 'Liszt', 'Schubert'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'How many semitones are in an octave?',
+    answers: ['12', '8', '10', '7'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What clef is used for violin music?',
+    answers: ['Treble', 'Bass', 'Alto', 'Tenor'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which scale degree is called the dominant?',
+    answers: ['5th', '3rd', '1st', '7th'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'Which pop star released the album "1989"?',
+    answers: ['Taylor Swift', 'Madonna', 'Katy Perry', 'Lady Gaga'],
+    correctAnswer: 0,
+  },
+  {
+    question: 'What does "a cappella" mean?',
+    answers: ['Singing without instruments', 'Singing softly', 'Singing loudly', 'Singing with vibrato'],
+    correctAnswer: 0,
+  },
+];
+
+export default musicTriviaQuestions;


### PR DESCRIPTION
## Summary
- add 24 music trivia question/answer pairs
- build reusable QuickQuiz engine that shuffles and scores questions
- wire up MusicTriviaQuickQuiz using the engine for 10-question sessions

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and unsafe member access in existing hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68af40a89db4833283dd905b85cc642d