### PR TITLE
chore: enforce supported Node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Chord Lab uses a progressive learning methodology:
 ## Development Setup
 
 ### Prerequisites
-- Node.js 20.19+ or 22.12+
+- Node.js 20.19–22.x (enforced via `package.json` `engines` field)
 - Git
 
 ### Quick Start

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.19 <23"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- restrict Node.js versions via `engines` field
- document supported Node range in README

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, unsafe assignments in src/hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68af41dac1b08332af1f8a9ef7499eb6