### PR TITLE
Add classroom countdown timer and quiz integration

### DIFF
--- a/src/components/classroom/CountdownTimer.tsx
+++ b/src/components/classroom/CountdownTimer.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useRef, useImperativeHandle, forwardRef, useEffect } from 'react';
+
+interface CountdownTimerProps {
+  onComplete?: () => void;
+}
+
+export interface CountdownTimerHandle {
+  start: (seconds: number) => void;
+  pause: () => void;
+  resume: () => void;
+}
+
+const CountdownTimer = forwardRef<CountdownTimerHandle, CountdownTimerProps>((
+  { onComplete },
+  ref
+) => {
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [isActive, setIsActive] = useState(false);
+  const totalRef = useRef(0);
+  const intervalRef = useRef<number>();
+
+  const clear = () => {
+    if (intervalRef.current !== undefined) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = undefined;
+    }
+  };
+
+  const tick = () => {
+    setSecondsLeft(prev => {
+      if (prev <= 1) {
+        clear();
+        setIsActive(false);
+        onComplete?.();
+        return 0;
+      }
+      return prev - 1;
+    });
+  };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      start: (seconds: number) => {
+        clear();
+        totalRef.current = seconds;
+        setSecondsLeft(seconds);
+        setIsActive(true);
+        intervalRef.current = window.setInterval(tick, 1000);
+      },
+      pause: () => {
+        clear();
+        setIsActive(false);
+      },
+      resume: () => {
+        if (!isActive && secondsLeft > 0) {
+          setIsActive(true);
+          intervalRef.current = window.setInterval(tick, 1000);
+        }
+      },
+    }),
+    [isActive, secondsLeft]
+  );
+
+  useEffect(() => {
+    return clear;
+  }, []);
+
+  const progress = totalRef.current ? (secondsLeft / totalRef.current) * 100 : 0;
+  const warning = secondsLeft <= 60;
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <div className="w-full h-2 bg-gray-200">
+        <div
+          className={`h-full transition-all duration-1000 ${warning ? 'bg-red-500' : 'bg-blue-500'}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <div
+        className={`mt-2 text-4xl font-bold ${warning ? 'text-red-600' : 'text-gray-800 dark:text-gray-100'}`}
+      >
+        {String(Math.floor(secondsLeft / 60)).padStart(2, '0')}:{String(secondsLeft % 60).padStart(2, '0')}
+      </div>
+    </div>
+  );
+});
+
+export default CountdownTimer;

--- a/src/components/classroom/QuickQuiz.tsx
+++ b/src/components/classroom/QuickQuiz.tsx
@@ -1,0 +1,39 @@
+import React, { useRef, useEffect, useState } from 'react';
+import CountdownTimer, { CountdownTimerHandle } from './CountdownTimer';
+
+const QuickQuiz: React.FC = () => {
+  const timerRef = useRef<CountdownTimerHandle>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    timerRef.current?.start(600);
+  }, []);
+
+  const revealAnswer = () => {
+    setRevealed(true);
+    timerRef.current?.pause();
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <CountdownTimer ref={timerRef} onComplete={() => setRevealed(true)} />
+      <div className="mt-4">
+        <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-2">
+          Drop the V of D minor
+        </h3>
+        {revealed ? (
+          <p className="text-green-600 font-semibold">Answer: A or A7</p>
+        ) : (
+          <button
+            onClick={revealAnswer}
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            Reveal Answer
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QuickQuiz;


### PR DESCRIPTION
## Summary
- add reusable CountdownTimer with start, pause, resume, and onComplete hooks
- show remaining time numerically and as a bar that turns red in final minute
- integrate timer into new QuickQuiz component that defaults to 10 minutes and pauses on reveal

## Testing
- `npm test`
- `npm run lint` *(fails: 45 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af40b000ec833299fcfb649bf1ee50