### PR TITLE
Add practice summary page and progress navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import OnboardingFlow from './components/onboarding/OnboardingFlow'
 import { AchievementProvider } from './contexts/AchievementContext'
 import { AchievementToast } from './components/achievements/AchievementToast'
 import { ProfilePage } from './components/profile/ProfilePage'
+import PracticeSummary from './components/practice-mode/PracticeSummary'
 
 function App() {
   const { classroomMode, toggleClassroomMode } = useClassroomMode()
@@ -51,14 +52,17 @@ function App() {
       <NavLink to="/wheel" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
         Chord Wheel
       </NavLink>
-      <NavLink to="/metronome" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
+      <NavLink to="/metronome" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}> 
         Metronome
       </NavLink>
-      <NavLink to="/classroom" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
+      <NavLink to="/classroom" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}> 
         Classroom
       </NavLink>
-       <NavLink to="/profile" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}>
-        Profile
+      <NavLink to="/progress" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}> 
+        Progress
+      </NavLink>
+      <NavLink to="/profile" className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkIdle}`}> 
+       Profile
       </NavLink>
     </>
   )
@@ -173,6 +177,7 @@ function App() {
             <Route path="/wheel" element={<ChordWheel />} />
             <Route path="/metronome" element={<Metronome />} />
             <Route path="/classroom" element={<ClassroomMode />} />
+            <Route path="/progress" element={<PracticeSummary />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/practice-mode/PracticeSummary.test.tsx
+++ b/src/components/practice-mode/PracticeSummary.test.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+import { render, screen } from '@testing-library/react';
+import PracticeSummary from './PracticeSummary';
+import { AchievementProvider } from '../../contexts/AchievementContext';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('PracticeSummary', () => {
+  it('displays stats and recent achievements from localStorage', () => {
+    localStorage.setItem(
+      'practiceStats',
+      JSON.stringify({ totalPracticeTime: 60000, chordsPlayed: 5 })
+    );
+    localStorage.setItem(
+      'unlockedAchievements',
+      JSON.stringify(['FIRST_CHORD'])
+    );
+
+    render(
+      <AchievementProvider>
+        <PracticeSummary />
+      </AchievementProvider>
+    );
+
+    expect(screen.getByText('Total Time:').parentElement).toHaveTextContent(
+      '1m 00s'
+    );
+    expect(screen.getByText('Chords Played:').parentElement).toHaveTextContent(
+      '5'
+    );
+    expect(screen.getByText('First Chord!')).toBeInTheDocument();
+  });
+});
+

--- a/src/components/practice-mode/PracticeSummary.tsx
+++ b/src/components/practice-mode/PracticeSummary.tsx
@@ -1,0 +1,63 @@
+import { FC, useEffect, useState } from 'react';
+import { useAchievements } from '../../contexts/AchievementContext';
+import { achievements } from '../../data/achievements';
+
+const PracticeSummary: FC = () => {
+  const [totalPracticeTime, setTotalPracticeTime] = useState(0);
+  const [chordsPlayed, setChordsPlayed] = useState(0);
+  const { unlockedAchievements } = useAchievements();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('practiceStats');
+    if (stored) {
+      const stats = JSON.parse(stored) as {
+        totalPracticeTime?: number;
+        chordsPlayed?: number;
+      };
+      setTotalPracticeTime(stats.totalPracticeTime ?? 0);
+      setChordsPlayed(stats.chordsPlayed ?? 0);
+    }
+  }, []);
+
+  const formatTime = (time: number) => {
+    const minutes = Math.floor(time / 60000);
+    const seconds = Math.floor((time % 60000) / 1000);
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+  };
+
+  const recentIds = Array.from(unlockedAchievements).slice(-3).reverse();
+  const recent = recentIds.map((id) => achievements[id]).filter(Boolean);
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4">Practice Summary</h2>
+      <div className="space-y-2">
+        <div>
+          <span className="font-semibold">Total Time:</span>{' '}
+          {formatTime(totalPracticeTime)}
+        </div>
+        <div>
+          <span className="font-semibold">Chords Played:</span> {chordsPlayed}
+        </div>
+      </div>
+      <div className="mt-6">
+        <h3 className="font-semibold mb-2">Recent Achievements</h3>
+        {recent.length > 0 ? (
+          <ul className="space-y-2">
+            {recent.map((ach) => (
+              <li key={ach.id} className="flex items-center space-x-2">
+                <span className="text-xl">{ach.icon}</span>
+                <span>{ach.name}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No achievements yet.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PracticeSummary;
+


### PR DESCRIPTION
## Summary
- introduce `PracticeSummary` component to show stored practice time, chords played, and recent achievements
- add Progress page with navigation link and route
- store and load practice stats from `localStorage` so summary persists

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: @typescript-eslint issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68af41e0b0248332b8614d6a3f1e4e22