### PR TITLE
Embed finger numbers in chord positions

### DIFF
--- a/src/components/classroom/ClassroomDisplay.tsx
+++ b/src/components/classroom/ClassroomDisplay.tsx
@@ -4,7 +4,7 @@ import PianoDiagram from '../diagrams/PianoDiagram'
 
 interface ChordDefinition {
   notes: string[];
-  guitarPositions: { string: number; fret: number }[];
+  guitarPositions: { string: number; fret: number; finger?: number }[];
 }
 
 interface ClassroomDisplayProps {

--- a/src/components/classroom/ClassroomMode.tsx
+++ b/src/components/classroom/ClassroomMode.tsx
@@ -18,16 +18,58 @@ const numeralMap: Record<string, number> = {
 
 interface ChordDefinition {
   notes: string[];
-  guitarPositions: { string: number; fret: number }[];
+  guitarPositions: { string: number; fret: number; finger?: number }[];
 }
 
 const chordData: Record<string, ChordDefinition> = {
-  C: { notes: ['C4', 'E4', 'G4'], guitarPositions: [{ string: 2, fret: 1 }, { string: 4, fret: 2 }, { string: 5, fret: 3 }] },
-  G: { notes: ['G3', 'B3', 'D4'], guitarPositions: [{ string: 1, fret: 3 }, { string: 5, fret: 2 }, { string: 6, fret: 3 }] },
-  Am: { notes: ['A3', 'C4', 'E4'], guitarPositions: [{ string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 2 }] },
-  F: { notes: ['F3', 'A3', 'C4'], guitarPositions: [{ string: 1, fret: 1 }, { string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 3 }] },
-  D: { notes: ['D4', 'F#4', 'A4'], guitarPositions: [{ string: 1, fret: 2 }, { string: 2, fret: 3 }, { string: 3, fret: 2 }] },
-  Em: { notes: ['E3', 'G3', 'B3'], guitarPositions: [{ string: 4, fret: 2 }, { string: 5, fret: 2 }] },
+  C: {
+    notes: ['C4', 'E4', 'G4'],
+    guitarPositions: [
+      { string: 2, fret: 1, finger: 1 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 3, finger: 3 },
+    ],
+  },
+  G: {
+    notes: ['G3', 'B3', 'D4'],
+    guitarPositions: [
+      { string: 1, fret: 3, finger: 3 },
+      { string: 5, fret: 2, finger: 2 },
+      { string: 6, fret: 3, finger: 4 },
+    ],
+  },
+  Am: {
+    notes: ['A3', 'C4', 'E4'],
+    guitarPositions: [
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 2, finger: 3 },
+    ],
+  },
+  F: {
+    notes: ['F3', 'A3', 'C4'],
+    guitarPositions: [
+      { string: 1, fret: 1, finger: 1 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 3, finger: 3 },
+    ],
+  },
+  D: {
+    notes: ['D4', 'F#4', 'A4'],
+    guitarPositions: [
+      { string: 1, fret: 2, finger: 2 },
+      { string: 2, fret: 3, finger: 3 },
+      { string: 3, fret: 2, finger: 1 },
+    ],
+  },
+  Em: {
+    notes: ['E3', 'G3', 'B3'],
+    guitarPositions: [
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 2, finger: 3 },
+    ],
+  },
   // Add other chords as needed
 };
 

--- a/src/components/diagrams/GuitarDiagram.tsx
+++ b/src/components/diagrams/GuitarDiagram.tsx
@@ -18,7 +18,6 @@ interface Barre {
 interface GuitarDiagramProps {
   chordName: string;
   positions: FretPosition[];
-  fingers?: number[]; // To match feature branch, although main uses pos.finger
   noteStrip?: (string | null)[];
   barres?: Barre[];
   onPlayNote?: (string: number, fret: number) => void;

--- a/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
+++ b/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
@@ -5,64 +5,57 @@ import GuitarDiagram from '../../diagrams/GuitarDiagram'
 type ChordName = 'C' | 'F' | 'G' | 'Am' | 'D' | 'Em'
 interface ChordData {
   name: ChordName
-  guitarPositions: { string: number; fret: number }[]
-  guitarFingers: number[]
+  guitarPositions: { string: number; fret: number; finger: number }[]
 }
 
 const chords: Record<ChordName, ChordData> = {
   C: {
     name: 'C',
     guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 3, finger: 3 },
     ],
-    guitarFingers: [1, 2, 3],
   },
   F: {
     name: 'F',
     guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
+      { string: 1, fret: 1, finger: 1 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 3, finger: 3 },
     ],
-    guitarFingers: [1, 1, 2, 3],
   },
   G: {
     name: 'G',
     guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
+      { string: 1, fret: 3, finger: 3 },
+      { string: 5, fret: 2, finger: 2 },
+      { string: 6, fret: 3, finger: 4 },
     ],
-    guitarFingers: [3, 2, 4],
   },
   Am: {
     name: 'Am',
     guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 2, finger: 3 },
     ],
-    guitarFingers: [1, 2, 3],
   },
   D: {
     name: 'D',
     guitarPositions: [
-      { string: 1, fret: 2 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
+      { string: 1, fret: 2, finger: 2 },
+      { string: 2, fret: 3, finger: 3 },
+      { string: 3, fret: 2, finger: 1 },
     ],
-    guitarFingers: [2, 3, 1],
   },
   Em: {
     name: 'Em',
     guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 2, finger: 3 },
     ],
-    guitarFingers: [2, 3],
   },
 }
 
@@ -125,7 +118,6 @@ const ChordSwitchingExercise: React.FC<ChordSwitchingExerciseProps> = ({ progres
             <GuitarDiagram
               chordName={chords[chordName].name}
               positions={chords[chordName].guitarPositions}
-              fingers={chords[chordName].guitarFingers}
             />
           </div>
         ))}

--- a/src/components/practice-mode/InstrumentPanel.tsx
+++ b/src/components/practice-mode/InstrumentPanel.tsx
@@ -4,8 +4,7 @@ import PianoDiagram from '../diagrams/PianoDiagram';
 
 interface Chord {
   name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers: number[];
+  guitarPositions: { string: number; fret: number; finger: number }[];
   pianoNotes: string[];
 }
 
@@ -62,7 +61,6 @@ const InstrumentPanel: FC<InstrumentPanelProps> = ({
             <GuitarDiagram
               chordName={chord.name}
               positions={chord.guitarPositions}
-              fingers={chord.guitarFingers}
               onPlayNote={playGuitarNote}
             />
           ) : (

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -12,8 +12,7 @@ import InstrumentPanel from './InstrumentPanel';
 
 interface Chord {
   name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers: number[];
+  guitarPositions: { string: number; fret: number; finger: number }[];
   pianoNotes: string[];
 }
 
@@ -41,63 +40,57 @@ const chords: Chord[] = [
   {
     name: 'C',
     guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 3, finger: 3 },
     ],
-    guitarFingers: [1, 2, 3],
     pianoNotes: ['C4', 'E4', 'G4'],
   },
   {
     name: 'G',
     guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 2, fret: 0 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
+      { string: 1, fret: 3, finger: 3 },
+      { string: 2, fret: 0, finger: 0 },
+      { string: 5, fret: 2, finger: 2 },
+      { string: 6, fret: 3, finger: 4 },
     ],
-    guitarFingers: [3, 0, 2, 4],
     pianoNotes: ['G3', 'B3', 'D4'],
   },
   {
     name: 'F',
     guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
+      { string: 1, fret: 1, finger: 1 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 3, finger: 3 },
     ],
-    guitarFingers: [1, 1, 2, 3],
     pianoNotes: ['F3', 'A3', 'C4'],
   },
   // Minors
   {
     name: 'Am',
     guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 4, fret: 2, finger: 3 },
     ],
-    guitarFingers: [1, 2, 3],
     pianoNotes: ['A3', 'C4', 'E4'],
   },
   {
     name: 'Em',
     guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 5, fret: 2, finger: 3 },
     ],
-    guitarFingers: [2, 3],
     pianoNotes: ['E3', 'G3', 'B3'],
   },
   {
     name: 'Dm',
     guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
+      { string: 1, fret: 1, finger: 1 },
+      { string: 2, fret: 3, finger: 3 },
+      { string: 3, fret: 2, finger: 2 },
     ],
-    guitarFingers: [1, 3, 2],
     pianoNotes: ['D4', 'F4', 'A4'],
   },
 ];


### PR DESCRIPTION
## Summary
- Include finger numbers inside `guitarPositions` for practice mode and other chord sources
- Simplify `InstrumentPanel` and `GuitarDiagram` by dropping separate `fingers` props
- Update classroom mode data and switching exercise to the new position format

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 45 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af3d4d118c83328b79dc1fed75a50f