### PR TITLE
Centralize chord definitions and document official set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ An interactive music learning application that teaches piano and guitar chords t
 5. **Listen and Play**: Click notes/strings to hear sounds and practice timing
 
 ### Supported Chords
+The current official chord set focuses on commonly used shapes:
+
 - **Major chords**: C, F, G, D, A, E, B
 - **Minor chords**: Am, Em, Dm, Bm, F#m, C#m, G#m
+
+Chord definitions live in `src/data/chords.ts` so future additions remain consistent.
+
 - **Extensions coming soon**: 7th chords, suspended chords, and more
 
 ## Browser Compatibility

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,13 +1,10 @@
 import { Link } from 'react-router-dom';
+import { CHORDS } from '../data/chords';
 
 const Dashboard = () => {
   // Sample data for quick practice
-  const quickChords = [
-    { name: 'C', guitar: [{ string: 2, fret: 1 }, { string: 4, fret: 2 }, { string: 5, fret: 3 }], piano: ['C4', 'E4', 'G4'] },
-    { name: 'G', guitar: [{ string: 1, fret: 3 }, { string: 5, fret: 2 }, { string: 6, fret: 3 }], piano: ['G3', 'B3', 'D4'] },
-    { name: 'Am', guitar: [{ string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 2 }], piano: ['A3', 'C4', 'E4'] },
-    { name: 'F', guitar: [{ string: 1, fret: 1 }, { string: 2, fret: 1 }, { string: 3, fret: 2 }, { string: 4, fret: 3 }], piano: ['F3', 'A3', 'C4'] }
-  ];
+  const quickChords = CHORDS.filter(chord => ['C', 'G', 'Am', 'F'].includes(chord.name))
+    .map(chord => ({ name: chord.name, guitar: chord.guitarPositions, piano: chord.pianoNotes }));
   
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">

--- a/src/components/chord-builder/ChordProgressionBuilder.tsx
+++ b/src/components/chord-builder/ChordProgressionBuilder.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import useAudio from '../../hooks/useAudio';
+import { CHORDS } from '../../data/chords';
 
 interface Chord {
   id: string;
@@ -54,12 +55,10 @@ const ChordProgressionBuilder = () => {
     ];
   };
 
-  const chordDictionary: Record<string, string[]> = {};
-  ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'Am', 'Bm', 'Cm', 'Dm', 'Em', 'Fm', 'Gm'].forEach(
-    chord => {
-      chordDictionary[chord] = buildChord(chord);
-    }
-  );
+    const chordDictionary: Record<string, string[]> = {};
+    CHORDS.forEach(chord => {
+      chordDictionary[chord.name] = buildChord(chord.name);
+    });
 
   const handlePlay = async () => {
     initAudio();
@@ -94,7 +93,7 @@ const ChordProgressionBuilder = () => {
     }
   };
   
-  const commonChords = ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'Am', 'Bm', 'Cm', 'Dm', 'Em', 'Fm', 'Gm'];
+  const commonChords = CHORDS.map(chord => chord.name);
   
   return (
     <div className="bg-white rounded-xl shadow-lg p-6">

--- a/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
+++ b/src/components/learning-path/exercises/ChordSwitchingExercise.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import useMetronome from '../../../hooks/useMetronome'
 import GuitarDiagram from '../../diagrams/GuitarDiagram'
+import { CHORDS } from '../../../data/chords'
 
 type ChordName = 'C' | 'F' | 'G' | 'Am' | 'D' | 'Em'
 interface ChordData {
@@ -9,62 +10,18 @@ interface ChordData {
   guitarFingers: number[]
 }
 
-const chords: Record<ChordName, ChordData> = {
-  C: {
-    name: 'C',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
-    ],
-    guitarFingers: [1, 2, 3],
-  },
-  F: {
-    name: 'F',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
-    ],
-    guitarFingers: [1, 1, 2, 3],
-  },
-  G: {
-    name: 'G',
-    guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
-    ],
-    guitarFingers: [3, 2, 4],
-  },
-  Am: {
-    name: 'Am',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
-    ],
-    guitarFingers: [1, 2, 3],
-  },
-  D: {
-    name: 'D',
-    guitarPositions: [
-      { string: 1, fret: 2 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
-    ],
-    guitarFingers: [2, 3, 1],
-  },
-  Em: {
-    name: 'Em',
-    guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
-    ],
-    guitarFingers: [2, 3],
-  },
-}
+const chordNames: ChordName[] = ['C', 'F', 'G', 'Am', 'D', 'Em']
+const chords: Record<ChordName, ChordData> = chordNames.reduce((acc, name) => {
+  const chord = CHORDS.find(c => c.name === name)
+  if (chord) {
+    acc[name] = {
+      name,
+      guitarPositions: chord.guitarPositions,
+      guitarFingers: chord.guitarFingers,
+    }
+  }
+  return acc
+}, {} as Record<ChordName, ChordData>)
 
 interface ChordSwitchingExerciseProps {
   progression: ChordName[]

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -10,14 +10,7 @@ import Statistics from './Statistics';
 import PracticeMetronomeControls from './PracticeMetronomeControls';
 import InstrumentPanel from './InstrumentPanel';
 import { useHighestUnlockedLevel } from '../learning-path/LearningPathway';
-
-interface Chord {
-  name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers: number[];
-  pianoNotes: string[];
-  level: number;
-}
+import { CHORDS, type Chord } from '../../data/chords';
 
 const MAJORS_ORDER = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'Db', 'Ab', 'Eb', 'Bb', 'F'] as const;
 type MajorKey = (typeof MAJORS_ORDER)[number];
@@ -37,78 +30,8 @@ const RELATIVE_MINORS: Record<MajorKey, string> = {
   F: 'Dm',
 };
 
-// Sample chord data
-const chords: Chord[] = [
-  // Majors
-  {
-    name: 'C',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['C4', 'E4', 'G4'],
-    level: 2,
-  },
-  {
-    name: 'G',
-    guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 2, fret: 0 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
-    ],
-    guitarFingers: [3, 0, 2, 4],
-    pianoNotes: ['G3', 'B3', 'D4'],
-    level: 3,
-  },
-  {
-    name: 'F',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
-    ],
-    guitarFingers: [1, 1, 2, 3],
-    pianoNotes: ['F3', 'A3', 'C4'],
-    level: 2,
-  },
-  // Minors
-  {
-    name: 'Am',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['A3', 'C4', 'E4'],
-    level: 3,
-  },
-  {
-    name: 'Em',
-    guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
-    ],
-    guitarFingers: [2, 3],
-    pianoNotes: ['E3', 'G3', 'B3'],
-    level: 4,
-  },
-  {
-    name: 'Dm',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
-    ],
-    guitarFingers: [1, 3, 2],
-    pianoNotes: ['D4', 'F4', 'A4'],
-    level: 4,
-  },
-];
+// Centralized chord data
+const chords: Chord[] = CHORDS;
 
 function getDiatonicForKey(keyCenter: MajorKey) {
   const idx = MAJORS_ORDER.indexOf(keyCenter);

--- a/src/data/chords.ts
+++ b/src/data/chords.ts
@@ -1,0 +1,179 @@
+export interface Chord {
+  name: string;
+  guitarPositions: { string: number; fret: number }[];
+  guitarFingers: number[];
+  pianoNotes: string[];
+  level: number;
+}
+
+export const CHORDS: Chord[] = [
+  {
+    name: 'C',
+    guitarPositions: [
+      { string: 2, fret: 1 },
+      { string: 4, fret: 2 },
+      { string: 5, fret: 3 },
+    ],
+    guitarFingers: [1, 2, 3],
+    pianoNotes: ['C4', 'E4', 'G4'],
+    level: 2,
+  },
+  {
+    name: 'G',
+    guitarPositions: [
+      { string: 1, fret: 3 },
+      { string: 2, fret: 0 },
+      { string: 5, fret: 2 },
+      { string: 6, fret: 3 },
+    ],
+    guitarFingers: [3, 0, 2, 4],
+    pianoNotes: ['G3', 'B3', 'D4'],
+    level: 3,
+  },
+  {
+    name: 'F',
+    guitarPositions: [
+      { string: 1, fret: 1 },
+      { string: 2, fret: 1 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 3 },
+    ],
+    guitarFingers: [1, 1, 2, 3],
+    pianoNotes: ['F3', 'A3', 'C4'],
+    level: 2,
+  },
+  {
+    name: 'D',
+    guitarPositions: [
+      { string: 1, fret: 2 },
+      { string: 2, fret: 3 },
+      { string: 3, fret: 2 },
+    ],
+    guitarFingers: [2, 3, 1],
+    pianoNotes: ['D4', 'F#4', 'A4'],
+    level: 3,
+  },
+  {
+    name: 'A',
+    guitarPositions: [
+      { string: 2, fret: 2 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 2 },
+    ],
+    guitarFingers: [2, 1, 3],
+    pianoNotes: ['A3', 'C#4', 'E4'],
+    level: 3,
+  },
+  {
+    name: 'E',
+    guitarPositions: [
+      { string: 3, fret: 1 },
+      { string: 4, fret: 2 },
+      { string: 5, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 2],
+    pianoNotes: ['E3', 'G#3', 'B3'],
+    level: 3,
+  },
+  {
+    name: 'B',
+    guitarPositions: [
+      { string: 1, fret: 2 },
+      { string: 2, fret: 4 },
+      { string: 3, fret: 4 },
+      { string: 4, fret: 4 },
+      { string: 5, fret: 2 },
+    ],
+    guitarFingers: [1, 4, 3, 2, 1],
+    pianoNotes: ['B3', 'D#4', 'F#4'],
+    level: 4,
+  },
+  {
+    name: 'Am',
+    guitarPositions: [
+      { string: 2, fret: 1 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 2 },
+    ],
+    guitarFingers: [1, 2, 3],
+    pianoNotes: ['A3', 'C4', 'E4'],
+    level: 3,
+  },
+  {
+    name: 'Em',
+    guitarPositions: [
+      { string: 4, fret: 2 },
+      { string: 5, fret: 2 },
+    ],
+    guitarFingers: [2, 3],
+    pianoNotes: ['E3', 'G3', 'B3'],
+    level: 4,
+  },
+  {
+    name: 'Dm',
+    guitarPositions: [
+      { string: 1, fret: 1 },
+      { string: 2, fret: 3 },
+      { string: 3, fret: 2 },
+    ],
+    guitarFingers: [1, 3, 2],
+    pianoNotes: ['D4', 'F4', 'A4'],
+    level: 4,
+  },
+  {
+    name: 'Bm',
+    guitarPositions: [
+      { string: 1, fret: 2 },
+      { string: 2, fret: 3 },
+      { string: 3, fret: 4 },
+      { string: 4, fret: 4 },
+      { string: 5, fret: 2 },
+    ],
+    guitarFingers: [1, 2, 4, 3, 1],
+    pianoNotes: ['B3', 'D4', 'F#4'],
+    level: 4,
+  },
+  {
+    name: 'F#m',
+    guitarPositions: [
+      { string: 1, fret: 2 },
+      { string: 2, fret: 2 },
+      { string: 3, fret: 2 },
+      { string: 4, fret: 4 },
+      { string: 5, fret: 4 },
+      { string: 6, fret: 2 },
+    ],
+    guitarFingers: [1, 1, 1, 4, 3, 1],
+    pianoNotes: ['F#3', 'A3', 'C#4'],
+    level: 4,
+  },
+  {
+    name: 'C#m',
+    guitarPositions: [
+      { string: 1, fret: 4 },
+      { string: 2, fret: 5 },
+      { string: 3, fret: 6 },
+      { string: 4, fret: 6 },
+      { string: 5, fret: 4 },
+    ],
+    guitarFingers: [1, 2, 4, 3, 1],
+    pianoNotes: ['C#4', 'E4', 'G#4'],
+    level: 4,
+  },
+  {
+    name: 'G#m',
+    guitarPositions: [
+      { string: 1, fret: 4 },
+      { string: 2, fret: 4 },
+      { string: 3, fret: 4 },
+      { string: 4, fret: 6 },
+      { string: 5, fret: 6 },
+      { string: 6, fret: 4 },
+    ],
+    guitarFingers: [1, 1, 1, 4, 3, 1],
+    pianoNotes: ['G#3', 'B3', 'D#4'],
+    level: 4,
+  },
+];
+
+export default CHORDS;


### PR DESCRIPTION
## Summary
- declare official major/minor chords in README and document centralized location
- add `src/data/chords.ts` containing shared chord definitions
- refactor dashboard, practice mode, chord progression builder, and chord switching exercise to use centralized data

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access and no-explicit-any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af41d0f448833292f324d877351d5c