### PR TITLE
Guard against undefined chord names in SongPractice

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -91,7 +91,8 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
-  const currentChord = selectedSong ? getChord(selectedSong.progression[currentChordIndex]) : null;
+  const chordName = selectedSong?.progression[currentChordIndex];
+  const currentChord = chordName ? getChord(chordName) : null;
 
   useEffect(() => {
     if (selectedSong) {


### PR DESCRIPTION
## Summary
- Guard chord lookup in SongPractice from undefined array values by checking chord name before fetching

## Testing
- `npm run build` *(fails: Cannot find name 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68af499f072c8332ab7da57570bd7d67