### PR TITLE
Add classroom scoreboard context and sample game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,9 @@ import { useTheme } from './contexts/ThemeContext'
 import ScrollingPractice from './components/practice-mode/ScrollingPractice'
 import ClassroomMode from './components/classroom/ClassroomMode'
 import TeacherDashboard from './components/classroom/TeacherDashboard'
+import TeacherGamesDashboard from './components/classroom/TeacherGamesDashboard'
+import { ScoreboardProvider } from './components/classroom/Scoreboard'
+import ExampleGame from './components/classroom/games/ExampleGame'
 // --- MERGED IMPORTS (from both branches) ---
 import { useUserProfile } from './contexts/UserProfileContext'
 import OnboardingFlow from './components/onboarding/OnboardingFlow'
@@ -177,6 +180,16 @@ function App() {
             <Route path="/metronome" element={<Metronome />} />
             <Route path="/classroom" element={<ClassroomMode />} />
             <Route path="/classroom/dashboard" element={<TeacherDashboard />} />
+            <Route
+              path="/classroom/games/*"
+              element={
+                <ScoreboardProvider>
+                  <TeacherGamesDashboard />
+                </ScoreboardProvider>
+              }
+            >
+              <Route path="example" element={<ExampleGame />} />
+            </Route>
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/classroom/Scoreboard.tsx
+++ b/src/components/classroom/Scoreboard.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+
+interface Team {
+  name: string
+  score: number
+}
+
+interface ScoreboardContextValue {
+  teams: Team[]
+  addTeam: (name: string) => void
+  incrementScore: (name: string, amount?: number) => void
+  resetScores: () => void
+}
+
+const ScoreboardContext = createContext<ScoreboardContextValue | undefined>(undefined)
+
+export const ScoreboardProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [teams, setTeams] = useState<Team[]>([])
+
+  const addTeam = (name: string) => {
+    setTeams(prev => {
+      if (prev.some(t => t.name === name)) return prev
+      return [...prev, { name, score: 0 }]
+    })
+  }
+
+  const incrementScore = (name: string, amount: number = 1) => {
+    setTeams(prev => prev.map(t => (t.name === name ? { ...t, score: t.score + amount } : t)))
+  }
+
+  const resetScores = () => {
+    setTeams(prev => prev.map(t => ({ ...t, score: 0 })))
+  }
+
+  return (
+    <ScoreboardContext.Provider value={{ teams, addTeam, incrementScore, resetScores }}>
+      {children}
+    </ScoreboardContext.Provider>
+  )
+}
+
+export const useScoreboard = () => {
+  const context = useContext(ScoreboardContext)
+  if (!context) throw new Error('useScoreboard must be used within a ScoreboardProvider')
+  return context
+}
+
+export const Scoreboard: React.FC = () => {
+  const { teams, resetScores } = useScoreboard()
+
+  if (teams.length === 0) return null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100">Scoreboard</h3>
+        <button
+          onClick={resetScores}
+          className="px-2 py-1 text-sm rounded bg-red-500 text-white hover:bg-red-600"
+        >
+          Reset
+        </button>
+      </div>
+      <ul>
+        {teams.map(team => (
+          <li key={team.name} className="flex justify-between py-1 text-gray-900 dark:text-gray-100">
+            <span>{team.name}</span>
+            <span>{team.score}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default Scoreboard
+

--- a/src/components/classroom/TeacherGamesDashboard.tsx
+++ b/src/components/classroom/TeacherGamesDashboard.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { Link, Outlet } from 'react-router-dom'
+import { Scoreboard, useScoreboard } from './Scoreboard'
+
+const TeacherGamesDashboard: React.FC = () => {
+  const { addTeam } = useScoreboard()
+  const [teamName, setTeamName] = useState('')
+
+  const handleAddTeam = () => {
+    const name = teamName.trim()
+    if (!name) return
+    addTeam(name)
+    setTeamName('')
+  }
+
+  return (
+    <div className="space-y-4">
+      <Scoreboard />
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={teamName}
+          onChange={e => setTeamName(e.target.value)}
+          placeholder="Add team"
+          className="flex-grow px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
+        />
+        <button
+          onClick={handleAddTeam}
+          className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+        >
+          Add Team
+        </button>
+      </div>
+      <Link
+        to="example"
+        className="inline-block px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors"
+      >
+        Play Example Game
+      </Link>
+      <Outlet />
+    </div>
+  )
+}
+
+export default TeacherGamesDashboard
+

--- a/src/components/classroom/games/ExampleGame.tsx
+++ b/src/components/classroom/games/ExampleGame.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Scoreboard, useScoreboard } from '../Scoreboard'
+
+const ExampleGame: React.FC = () => {
+  const { teams, incrementScore } = useScoreboard()
+
+  if (teams.length === 0) {
+    return <p className="text-gray-700 dark:text-gray-300">Add teams to start scoring.</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <Scoreboard />
+      <div className="space-y-2">
+        <h4 className="font-bold text-gray-800 dark:text-gray-100">Example Game</h4>
+        {teams.map(team => (
+          <button
+            key={team.name}
+            onClick={() => incrementScore(team.name)}
+            className="px-3 py-1 bg-green-500 text-white rounded-lg hover:bg-green-600"
+          >
+            {team.name} +1
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ExampleGame
+


### PR DESCRIPTION
## Summary
- add Scoreboard context with provider, hook, and UI
- show scoreboard in new TeacherGamesDashboard with team management
- wrap classroom games routes in ScoreboardProvider and include example game

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe any usage and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af3f4a91988332b56ffba93525fe09