### PR TITLE
Guard against undefined chord names in SongPractice

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -91,7 +91,8 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
-  const currentChord = selectedSong ? getChord(selectedSong.progression[currentChordIndex]) : null;
+  const chordName = selectedSong?.progression[currentChordIndex];
+  const currentChord = chordName ? getChord(chordName) : null;
 
   useEffect(() => {
     if (selectedSong) {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- Guard chord lookup in SongPractice from undefined array values by checking chord name before fetching
- Exclude test files from TypeScript app build to avoid missing test runner types

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af499f072c8332ab7da57570bd7d67