### PR TITLE
feat: manage audio clip for quick quiz

### DIFF
--- a/src/components/classroom/games/QuickQuiz.tsx
+++ b/src/components/classroom/games/QuickQuiz.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+
+export interface QuickQuizProps {
+  /** Source URL for the audio clip to play */
+  clipSrc?: string;
+}
+
+/**
+ * QuickQuiz provides a simple audio-based quiz player.
+ * It maintains a reference to the current HTMLAudioElement so that
+ * any previously playing audio can be paused and reset before a new
+ * clip is loaded. The audio element is cleaned up when the component
+ * unmounts.
+ */
+export default function QuickQuiz({ clipSrc }: QuickQuizProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    if (!clipSrc) return;
+
+    // Lazily create the audio element if needed
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+
+    const audio = audioRef.current;
+
+    // Pause and reset any previous playback before loading a new source
+    audio.pause();
+    audio.currentTime = 0;
+    audio.src = clipSrc;
+
+    void audio.play();
+  }, [clipSrc]);
+
+  useEffect(() => {
+    // Cleanup the audio element when the component unmounts
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.src = '';
+        audioRef.current.load();
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
+  return <div />;
+}


### PR DESCRIPTION
## Summary
- add QuickQuiz component and manage current audio clip with useRef
- pause and reset previous audio before loading new source
- cleanup audio element on unmount

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68afc44e52b88332a1645e75121b1efa