### PR TITLE
fix vitest imports and types

### DIFF
--- a/src/components/learning-path/quizzes/NameTheNoteQuiz.test.tsx
+++ b/src/components/learning-path/quizzes/NameTheNoteQuiz.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import NameTheNoteQuiz from './NameTheNoteQuiz';
-import { vi } from 'vitest';
+import { vi, test, expect } from 'vitest';
 
 const initAudioMock = vi.fn();
 const playNoteMock = vi.fn();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["vitest"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- explicitly import `test` and `expect` from vitest in `NameTheNoteQuiz` test
- add Vitest types to `tsconfig.app.json` so tests compile

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afc38650a0833287dd42e4e83e4708