### PR TITLE
feat: add generic quick quiz components

### DIFF
--- a/src/components/classroom/games/MajorMinorQuickQuiz.tsx
+++ b/src/components/classroom/games/MajorMinorQuickQuiz.tsx
@@ -1,0 +1,16 @@
+import QuickQuiz, { QuickQuizQuestion } from './QuickQuiz'
+
+const questions: QuickQuizQuestion<'Major' | 'Minor'>[] = [
+  { question: 'C', answer: 'Major' },
+  { question: 'Am', answer: 'Minor' },
+]
+
+export default function MajorMinorQuickQuiz() {
+  return (
+    <QuickQuiz<'Major' | 'Minor'>
+      questions={questions}
+      options={['Major', 'Minor']}
+    />
+  )
+}
+

--- a/src/components/classroom/games/QuickQuiz.tsx
+++ b/src/components/classroom/games/QuickQuiz.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+
+export interface QuickQuizQuestion<T extends string> {
+  question: string
+  answer: T
+}
+
+export interface QuickQuizProps<T extends string> {
+  questions: QuickQuizQuestion<T>[]
+  options: T[]
+}
+
+export default function QuickQuiz<T extends string>({ questions, options }: QuickQuizProps<T>) {
+  const [current, setCurrent] = useState(0)
+  const [selected, setSelected] = useState<T | null>(null)
+
+  const question = questions[current]
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p>{question.question}</p>
+      <div className="flex gap-2">
+        {options.map(option => (
+          <button
+            key={option}
+            className={`rounded border px-3 py-1 ${selected === option ? 'bg-blue-500 text-white' : ''}`}
+            onClick={() => setSelected(option)}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+      {selected && (
+        <button
+          className="self-start rounded border px-3 py-1"
+          onClick={() => {
+            setSelected(null)
+            setCurrent(i => Math.min(i + 1, questions.length - 1))
+          }}
+        >
+          Next
+        </button>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add generic `QuickQuizQuestion` and `QuickQuizProps` to support typed options and answers
- create `MajorMinorQuickQuiz` example using `'Major' | 'Minor'`

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afc44f83e48332b0cc7503bd34668a