### PR TITLE
feat: add generic shuffle utility

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react';
+import shuffle from '../../../utils/shuffle';
+
+const genres = [
+  'Rock',
+  'Jazz',
+  'Classical',
+  'Blues',
+  'Pop',
+];
+
+const GenreQuiz: React.FC = () => {
+  const shuffledGenres = useMemo(() => shuffle(genres), []);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-4">
+        Guess the Genre
+      </h3>
+      <ul className="list-disc pl-5 space-y-1">
+        {shuffledGenres.map((genre) => (
+          <li key={genre}>{genre}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default GenreQuiz;

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export default function shuffle<T>(array: T[]): T[] {
+  const copy = array.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}


### PR DESCRIPTION
## Summary
- add reusable generic `shuffle` helper
- use shared `shuffle` in GenreQuiz

## Testing
- `npm run lint` *(fails: Promise-returning function provided to attribute where a void return was expected, Unsafe assignment of an `any` value, Unexpected any. Specify a different type, Fast refresh only works when a file only exports components, etc.)*
- `npx eslint src/utils/shuffle.ts src/components/classroom/games/GenreQuiz.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc456a4448332b86556488f688c4f