### PR TITLE
feat: define score type for genre quiz

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+export interface Score {
+  correct: number;
+  attempted: number;
+}
+
+export default function GenreQuiz() {
+  const [score, setScore] = useState<Score>({ correct: 0, attempted: 0 });
+
+  const handleAnswer = (isCorrect: boolean) => {
+    setScore((prevScore: Score) => ({
+      correct: prevScore.correct + (isCorrect ? 1 : 0),
+      attempted: prevScore.attempted + 1,
+    }));
+  };
+
+  return (
+    <div>
+      <p>
+        Score: {score.correct} / {score.attempted}
+      </p>
+      <button onClick={() => handleAnswer(true)}>Correct</button>
+      <button onClick={() => handleAnswer(false)}>Incorrect</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Score interface for genre quiz
- type score state and updater

## Testing
- `npm run lint` (fails: existing lint errors)
- `npx eslint src/components/classroom/games/GenreQuiz.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afc458883083328ae34bf7c1e23e4f