### PR TITLE
test: add GenreQuiz tests

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo, useState } from 'react';
+import useAudio from '../../../hooks/useAudio';
+
+interface Song {
+  id: number;
+  note: string;
+  genre: string;
+}
+
+const GENRES = ['Rock', 'Jazz', 'Classical'];
+
+const GenreQuiz: React.FC = () => {
+  const { playNote } = useAudio();
+
+  const initialSongs: Song[] = useMemo(
+    () => [
+      { id: 1, note: 'C4', genre: 'Rock' },
+      { id: 2, note: 'D4', genre: 'Jazz' },
+      { id: 3, note: 'E4', genre: 'Classical' },
+    ],
+    []
+  );
+
+  const [songs, setSongs] = useState(initialSongs);
+  const [current, setCurrent] = useState(0);
+  const [score, setScore] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+
+  const handleGuess = (genre: string) => {
+    if (revealed) return;
+    setRevealed(true);
+    if (songs[current].genre === genre) {
+      setScore((s) => s + 1);
+    }
+  };
+
+  const shuffleSongs = () => {
+    const array = [...songs];
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    setSongs(array);
+    setCurrent(0);
+    setRevealed(false);
+  };
+
+  const resetScore = () => {
+    setScore(0);
+    setRevealed(false);
+  };
+
+  return (
+    <div>
+      <p data-testid="score">Score: {score}</p>
+      <button onClick={() => playNote(songs[current].note)}>Play Clip</button>
+      <div>
+        {GENRES.map((g) => (
+          <button key={g} onClick={() => handleGuess(g)} disabled={revealed}>
+            {g}
+          </button>
+        ))}
+      </div>
+      <button onClick={() => setRevealed(true)}>Reveal Answer</button>
+      {revealed && <p data-testid="answer">{songs[current].genre}</p>}
+      <button onClick={shuffleSongs}>Shuffle</button>
+      <button onClick={resetScore}>Reset Score</button>
+    </div>
+  );
+};
+
+export default GenreQuiz;

--- a/src/components/classroom/games/__tests__/GenreQuiz.test.tsx
+++ b/src/components/classroom/games/__tests__/GenreQuiz.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import GenreQuiz from '../GenreQuiz';
+import { vi } from 'vitest';
+
+const playNoteMock = vi.fn();
+
+vi.mock('../../../../hooks/useAudio', () => ({
+  __esModule: true,
+  default: () => ({
+    playNote: playNoteMock,
+  }),
+}));
+
+describe('GenreQuiz', () => {
+  beforeEach(() => {
+    playNoteMock.mockClear();
+  });
+
+  it('allows guessing and updates score', () => {
+    render(<GenreQuiz />);
+    const rockButton = screen.getByRole('button', { name: /Rock/i });
+    fireEvent.click(rockButton);
+    expect(screen.getByTestId('score')).toHaveTextContent('1');
+  });
+
+  it('shuffles songs', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0);
+    render(<GenreQuiz />);
+    const playButton = screen.getByRole('button', { name: /Play Clip/i });
+    fireEvent.click(playButton);
+    expect(playNoteMock).toHaveBeenLastCalledWith('C4');
+
+    const shuffleButton = screen.getByRole('button', { name: /Shuffle/i });
+    fireEvent.click(shuffleButton);
+    playNoteMock.mockClear();
+    fireEvent.click(playButton);
+    expect(playNoteMock).toHaveBeenLastCalledWith('D4');
+  });
+
+  it('reveals the answer when requested', () => {
+    render(<GenreQuiz />);
+    const revealButton = screen.getByRole('button', { name: /Reveal Answer/i });
+    fireEvent.click(revealButton);
+    expect(screen.getByTestId('answer')).toHaveTextContent('Rock');
+  });
+
+  it('resets score', () => {
+    render(<GenreQuiz />);
+    const rockButton = screen.getByRole('button', { name: /Rock/i });
+    fireEvent.click(rockButton);
+    expect(screen.getByTestId('score')).toHaveTextContent('1');
+    const resetButton = screen.getByRole('button', { name: /Reset Score/i });
+    fireEvent.click(resetButton);
+    expect(screen.getByTestId('score')).toHaveTextContent('0');
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple GenreQuiz classroom game component
- test guessing, shuffling, revealing answers, and resetting score with mocked audio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc4592b488332a274b2350a2d28d2