### PR TITLE
Handle potential undefined chord in SongPractice

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -91,8 +91,8 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
-  const chordName = selectedSong?.progression[currentChordIndex];
-  const currentChord = chordName ? getChord(chordName) : null;
+  const chordName = selectedSong?.progression[currentChordIndex] ?? null;
+  const currentChord = chordName ? getChord(chordName) ?? null : null;
 
   useEffect(() => {
     if (selectedSong) {


### PR DESCRIPTION
## Summary
- Guard current chord lookup so undefined chords default to null

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afcae202708332a44a4affa3f88a46