### PR TITLE
feat: introduce generic shuffle utility

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import shuffle from '../../../utils/shuffle';
+
+const GENRES = ['Blues', 'Classical', 'Country', 'Jazz', 'Rock'];
+
+export default function GenreQuiz() {
+  const options = useMemo(() => shuffle(GENRES), []);
+
+  return (
+    <div>
+      {options.map((genre) => (
+        <div key={genre}>{genre}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export default function shuffle<T>(array: T[]): T[] {
+  const result = array.slice();
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add generic `shuffle` utility for array randomization
- use new helper in `GenreQuiz` component

## Testing
- `npm run lint` *(fails: Parsing error due to parserOptions.project, 52 problems)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afcbebc39c8332b91708f90d50e74d