### PR TITLE
feat: add score interface to genre quiz

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+interface Score {
+  correct: number;
+  attempted: number;
+}
+
+export default function GenreQuiz() {
+  const [score, setScore] = useState<Score>({ correct: 0, attempted: 0 });
+
+  const handleAnswer = (isCorrect: boolean) => {
+    setScore((prev: Score) => ({
+      correct: prev.correct + (isCorrect ? 1 : 0),
+      attempted: prev.attempted + 1,
+    }));
+  };
+
+  return (
+    <div>
+      {score.correct}/{score.attempted}
+      <button onClick={() => handleAnswer(true)} style={{ display: 'none' }} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `Score` interface with `correct` and `attempted` fields for genre quiz
- type state with `Score` and annotate state updater

## Testing
- `npm run lint` *(fails: parsing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68afcbeca49c8332a74203c2ae372c5a