### PR TITLE
Manage audio element lifecycle in QuickQuiz

### DIFF
--- a/src/components/classroom/games/QuickQuiz.tsx
+++ b/src/components/classroom/games/QuickQuiz.tsx
@@ -13,15 +13,11 @@ export interface QuickQuizProps {
  * unmounts.
  */
 export default function QuickQuiz({ clipSrc }: QuickQuizProps) {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Keep a persistent audio element for the current clip
+  const audioRef = useRef<HTMLAudioElement>(new Audio());
 
   useEffect(() => {
     if (!clipSrc) return;
-
-    // Lazily create the audio element if needed
-    if (!audioRef.current) {
-      audioRef.current = new Audio();
-    }
 
     const audio = audioRef.current;
 
@@ -35,13 +31,11 @@ export default function QuickQuiz({ clipSrc }: QuickQuizProps) {
 
   useEffect(() => {
     // Cleanup the audio element when the component unmounts
+    const audio = audioRef.current;
     return () => {
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.src = '';
-        audioRef.current.load();
-        audioRef.current = null;
-      }
+      audio.pause();
+      audio.src = '';
+      audio.load();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- maintain persistent `HTMLAudioElement` with `useRef` in QuickQuiz
- pause/reset previous audio before loading new clip
- clean up audio resource when component unmounts

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: The file was not found in any of the provided project(s)...)*
- `npx eslint src/components/classroom/games/QuickQuiz.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afcbf254048332aa75e3aa65d0edbb