### PR TITLE
Memoize chord quality questions in MajorMinorQuickQuiz

### DIFF
--- a/src/components/classroom/games/MajorMinorQuickQuiz.tsx
+++ b/src/components/classroom/games/MajorMinorQuickQuiz.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+export interface ChordQualityQuestion {
+  chord: string;
+  quality: 'major' | 'minor';
+}
+
+// Simple list of chord quality questions.
+// In the real application this might be fetched or computed elsewhere.
+const chordQualityQuestions: ChordQualityQuestion[] = [
+  { chord: 'C', quality: 'major' },
+  { chord: 'Am', quality: 'minor' },
+];
+
+export default function MajorMinorQuickQuiz() {
+  // Memoize the mapped questions so the array reference remains stable
+  // between renders and avoids unnecessary re-renders downstream.
+  const questionItems = useMemo(
+    () => chordQualityQuestions.map(({ chord, quality }) => `${chord} is ${quality}`),
+    [chordQualityQuestions],
+  );
+
+  return (
+    <ul>
+      {questionItems.map((text, idx) => (
+        <li key={idx}>{text}</li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add MajorMinorQuickQuiz component
- memoize mapping of chord quality questions to prevent unnecessary recalculations

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser, among other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afcbf364948332a5564658a4fe0beb