### PR TITLE
feat: track correct and attempted answers in GenreQuiz

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -7,6 +7,11 @@ interface Song {
   genre: string;
 }
 
+interface Score {
+  correct: number;
+  attempted: number;
+}
+
 const GENRES = ['Rock', 'Jazz', 'Classical'];
 
 const GenreQuiz: React.FC = () => {
@@ -23,15 +28,16 @@ const GenreQuiz: React.FC = () => {
 
   const [songs, setSongs] = useState(initialSongs);
   const [current, setCurrent] = useState(0);
-  const [score, setScore] = useState(0);
+  const [score, setScore] = useState<Score>({ correct: 0, attempted: 0 });
   const [revealed, setRevealed] = useState(false);
 
   const handleGuess = (genre: string) => {
     if (revealed) return;
     setRevealed(true);
-    if (songs[current].genre === genre) {
-      setScore((s) => s + 1);
-    }
+    setScore((prev: Score) => ({
+      correct: prev.correct + (songs[current].genre === genre ? 1 : 0),
+      attempted: prev.attempted + 1,
+    }));
   };
 
   const shuffleSongs = () => {
@@ -46,13 +52,15 @@ const GenreQuiz: React.FC = () => {
   };
 
   const resetScore = () => {
-    setScore(0);
+    setScore({ correct: 0, attempted: 0 });
     setRevealed(false);
   };
 
   return (
     <div>
-      <p data-testid="score">Score: {score}</p>
+      <p data-testid="score">
+        Score: {score.correct}/{score.attempted}
+      </p>
       <button onClick={() => playNote(songs[current].note)}>Play Clip</button>
       <div>
         {GENRES.map((g) => (

--- a/src/components/classroom/games/__tests__/GenreQuiz.test.tsx
+++ b/src/components/classroom/games/__tests__/GenreQuiz.test.tsx
@@ -20,7 +20,7 @@ describe('GenreQuiz', () => {
     render(<GenreQuiz />);
     const rockButton = screen.getByRole('button', { name: /Rock/i });
     fireEvent.click(rockButton);
-    expect(screen.getByTestId('score')).toHaveTextContent('1');
+    expect(screen.getByTestId('score')).toHaveTextContent('1/1');
   });
 
   it('shuffles songs', () => {
@@ -48,9 +48,9 @@ describe('GenreQuiz', () => {
     render(<GenreQuiz />);
     const rockButton = screen.getByRole('button', { name: /Rock/i });
     fireEvent.click(rockButton);
-    expect(screen.getByTestId('score')).toHaveTextContent('1');
+    expect(screen.getByTestId('score')).toHaveTextContent('1/1');
     const resetButton = screen.getByRole('button', { name: /Reset Score/i });
     fireEvent.click(resetButton);
-    expect(screen.getByTestId('score')).toHaveTextContent('0');
+    expect(screen.getByTestId('score')).toHaveTextContent('0/0');
   });
 });


### PR DESCRIPTION
## Summary
- add `Score` interface for tracking `correct` and `attempted`
- update GenreQuiz to use `Score` state and show score as correct/attempted
- adjust GenreQuiz tests to match new score structure

## Testing
- `npm test` *(fails: PracticeMode test)*
- `npm run lint` *(fails: multiple repository-wide lint errors)*
- `npx eslint src/components/classroom/games/GenreQuiz.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68afd0fcd2d48332a71ced15e1733b1b