### PR TITLE
feat: add shuffle utility

### DIFF
--- a/src/components/classroom/games/GenreQuiz.tsx
+++ b/src/components/classroom/games/GenreQuiz.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import useAudio from '../../../hooks/useAudio';
+import { shuffle } from '../../../utils/shuffle';
 
 interface Song {
   id: number;
@@ -35,12 +36,7 @@ const GenreQuiz: React.FC = () => {
   };
 
   const shuffleSongs = () => {
-    const array = [...songs];
-    for (let i = array.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [array[i], array[j]] = [array[j], array[i]];
-    }
-    setSongs(array);
+    setSongs(shuffle(songs));
     setCurrent(0);
     setRevealed(false);
   };

--- a/src/utils/shuffle.test.ts
+++ b/src/utils/shuffle.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shuffle } from './shuffle';
+
+describe('shuffle', () => {
+  it('shuffles array without mutating original', () => {
+    const arr = [1, 2, 3];
+    const spy = vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0);
+    const result = shuffle(arr);
+    expect(result).toEqual([2, 3, 1]);
+    expect(arr).toEqual([1, 2, 3]);
+    spy.mockRestore();
+  });
+});
+

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,9 @@
+export function shuffle<T>(array: T[]): T[] {
+  const copy = [...array];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+


### PR DESCRIPTION
## Summary
- add generic array shuffle helper
- refactor GenreQuiz to use shared shuffle
- cover shuffle with unit test

## Testing
- `npm run lint` *(fails: Parsing error: "parserOptions.project" ... )*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd0296a988332bad96008f5050ffe