### PR TITLE
refactor: precompute chord quality questions

### DIFF
--- a/src/components/classroom/games/MajorMinorQuickQuiz.tsx
+++ b/src/components/classroom/games/MajorMinorQuickQuiz.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 export interface ChordQualityQuestion {
   chord: string;
   quality: 'major' | 'minor';
@@ -12,14 +10,13 @@ const chordQualityQuestions: ChordQualityQuestion[] = [
   { chord: 'Am', quality: 'minor' },
 ];
 
-export default function MajorMinorQuickQuiz() {
-  // Memoize the mapped questions so the array reference remains stable
-  // between renders and avoids unnecessary re-renders downstream.
-  const questionItems = useMemo(
-    () => chordQualityQuestions.map(({ chord, quality }) => `${chord} is ${quality}`),
-    [chordQualityQuestions],
-  );
+// Precompute mapped questions so the array reference remains stable
+// and avoids unnecessary work during component renders.
+const questionItems = chordQualityQuestions.map(
+  ({ chord, quality }) => `${chord} is ${quality}`,
+);
 
+export default function MajorMinorQuickQuiz() {
   return (
     <ul>
       {questionItems.map((text, idx) => (


### PR DESCRIPTION
## Summary
- precompute mapped chord quality questions outside component to keep stable references

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: parsing errors and lint warnings across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68afd02430208332b62863072abd868e