### PR TITLE
Handle undefined chord in SongPractice

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -91,8 +91,10 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
-  const chordName = selectedSong?.progression[currentChordIndex] ?? null;
-  const currentChord = chordName ? getChord(chordName) ?? null : null;
+  const chordName: string | null =
+    selectedSong?.progression[currentChordIndex] ?? null;
+  const currentChord: Chord | null =
+    chordName ? getChord(chordName) ?? null : null;
 
   useEffect(() => {
     if (selectedSong) {


### PR DESCRIPTION
## Summary
- Explicitly coerce song progression lookup to `Chord | null` in SongPractice

## Testing
- `npm run build` *(fails: ClassroomMode.tsx unused var, PracticeMode.tsx type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68afd46ff7088332976a099d1576e35e