### PR TITLE
Handle undefined chord in SongPractice

### DIFF
--- a/src/components/classroom/ClassroomMode.tsx
+++ b/src/components/classroom/ClassroomMode.tsx
@@ -3,7 +3,7 @@ import { getDiatonicChords } from '../../utils/music-theory'
 import GuitarDiagram from '../diagrams/GuitarDiagram'
 import PianoDiagram from '../diagrams/PianoDiagram'
 import ClassroomDisplay from '../classroom/ClassroomDisplay'
-import { chords as chordData, type ChordDefinition } from '../../data/chords'
+import { chords as chordData } from '../../data/chords'
 import { useNavigate } from 'react-router-dom'
 
 const keys = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'Db', 'Ab', 'Eb', 'Bb', 'F']

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -45,6 +45,7 @@ const chords: Chord[] = Object.entries(chordDictionary).map(([name, data]) => ({
   guitarPositions: data.guitarPositions,
   guitarFingers: data.guitarFingers ?? [],
   pianoNotes: data.pianoNotes,
+  level: data.level ?? 1,
 }));
 
 function getDiatonicForKey(keyCenter: MajorKey) {
@@ -81,7 +82,6 @@ const PracticeMode: FC = () => {
     challengeTime,
     startPracticeSession,
     stopPracticeSession,
-    incrementChordsPlayed,
     incrementUniqueChord,
     resetStreak,
     startChallenge,
@@ -169,7 +169,6 @@ const PracticeMode: FC = () => {
   };
 
   const nextChord = () => {
-    incrementChordsPlayed();
     const next = getRandomChord();
     if (next) setCurrentChord(next);
   };

--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -91,8 +91,10 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
-  const chordName = selectedSong?.progression[currentChordIndex] ?? null;
-  const currentChord = chordName ? getChord(chordName) ?? null : null;
+  const chordName: string | null =
+    selectedSong?.progression[currentChordIndex] ?? null;
+  const currentChord: Chord | null =
+    chordName ? getChord(chordName) ?? null : null;
 
   useEffect(() => {
     if (selectedSong) {

--- a/src/data/chords.ts
+++ b/src/data/chords.ts
@@ -7,6 +7,7 @@ export interface ChordDefinition {
   pianoNotes: string[];
   guitarPositions: FretPosition[];
   guitarFingers?: number[];
+  level?: number;
 }
 
 export const chords: Record<string, ChordDefinition> = {


### PR DESCRIPTION
## Summary
- Ensure SongPractice passes a `Chord | null` by coercing missing progression entries to null
- Remove unused import and strengthen chord typing with default levels to restore build
- Drop leftover `incrementChordsPlayed` reference and support optional levels in chord data

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd46ff7088332976a099d1576e35e