### PR TITLE
Handle unsupported chords in SongPractice

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FC } from 'react';
+import { useState, useEffect, type FC, useCallback } from 'react';
 import songs, { type Song } from '../../data/songs';
 import useMetronome from '../../hooks/useMetronome';
 import useAudio from '../../hooks/useAudio';
@@ -79,6 +79,10 @@ const chords: Chord[] = [
 const getChord = (name: string): Chord | null =>
   chords.find(c => c.name === name) ?? null;
 
+const supportedSongs = songs.filter(song =>
+  song.progression.every(ch => getChord(ch) !== null),
+);
+
 interface SongPracticeProps {
   onClose: () => void;
 }
@@ -88,6 +92,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
   const [currentChordIndex, setCurrentChordIndex] = useState(0);
   const [selectedInstrument, setSelectedInstrument] =
     useState<'guitar' | 'piano'>('guitar');
+  const [message, setMessage] = useState<string | null>(null);
   const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
   const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
 
@@ -110,6 +115,22 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
     }
   };
 
+  const nextChord = useCallback(() => {
+    if (!selectedSong) return;
+    setCurrentChordIndex(idx =>
+      (idx + 1) % selectedSong.progression.length,
+    );
+  }, [selectedSong]);
+
+  useEffect(() => {
+    if (chordName && !currentChord) {
+      setMessage(`Unsupported chord: ${chordName}. Skipping.`);
+      nextChord();
+    } else {
+      setMessage(null);
+    }
+  }, [chordName, currentChord, nextChord]);
+
   const handleStrum = () => {
     if (currentChord) {
       const notes =
@@ -118,11 +139,6 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
           : currentChord.guitarPositions.map(p => fretToNote(p.string, p.fret));
       playChord(notes, 1, selectedInstrument);
     }
-  };
-
-  const nextChord = () => {
-    if (!selectedSong) return;
-    setCurrentChordIndex((currentChordIndex + 1) % selectedSong.progression.length);
   };
 
   return (
@@ -145,7 +161,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
             Choose a Song
           </h3>
           <ul className="space-y-2">
-            {songs.map(song => (
+            {supportedSongs.map(song => (
               <li key={song.title}>
                 <button
                   onClick={() => {
@@ -169,6 +185,12 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
             {selectedSong.artist} • Key: {selectedSong.key} • Original Tempo:{' '}
             {selectedSong.bpm} BPM
           </p>
+
+          {message && (
+            <div className="mb-4 p-2 bg-yellow-100 text-yellow-800 rounded">
+              {message}
+            </div>
+          )}
 
           <div className="mb-4 flex flex-wrap gap-2">
             {selectedSong.progression.map((chordName, idx) => (


### PR DESCRIPTION
## Summary
- Warn and skip when a song progression contains chords without definitions
- Filter song list to those with supported chords to avoid unsupported entries

## Testing
- `npm test` *(fails: Unable to find an element by: [data-testid="current-chord-name"])*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd922f6288332bcd63b7ed514a0ae