### PR TITLE
refactor: centralize chord data

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -5,76 +5,7 @@ import useAudio from '../../hooks/useAudio';
 import PracticeMetronomeControls from './PracticeMetronomeControls';
 import InstrumentPanel from './InstrumentPanel';
 
-interface Chord {
-  name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers: number[];
-  pianoNotes: string[];
-}
-
-const chords: Chord[] = [
-  {
-    name: 'C',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 4, fret: 2 },
-      { string: 5, fret: 3 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['C4', 'E4', 'G4'],
-  },
-  {
-    name: 'G',
-    guitarPositions: [
-      { string: 1, fret: 3 },
-      { string: 2, fret: 0 },
-      { string: 5, fret: 2 },
-      { string: 6, fret: 3 },
-    ],
-    guitarFingers: [3, 0, 2, 4],
-    pianoNotes: ['G3', 'B3', 'D4'],
-  },
-  {
-    name: 'F',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 3 },
-    ],
-    guitarFingers: [1, 1, 2, 3],
-    pianoNotes: ['F3', 'A3', 'C4'],
-  },
-  {
-    name: 'Am',
-    guitarPositions: [
-      { string: 2, fret: 1 },
-      { string: 3, fret: 2 },
-      { string: 4, fret: 2 },
-    ],
-    guitarFingers: [1, 2, 3],
-    pianoNotes: ['A3', 'C4', 'E4'],
-  },
-  {
-    name: 'Em',
-    guitarPositions: [
-      { string: 4, fret: 2 },
-      { string: 5, fret: 2 },
-    ],
-    guitarFingers: [2, 3],
-    pianoNotes: ['E3', 'G3', 'B3'],
-  },
-  {
-    name: 'Dm',
-    guitarPositions: [
-      { string: 1, fret: 1 },
-      { string: 2, fret: 3 },
-      { string: 3, fret: 2 },
-    ],
-    guitarFingers: [1, 3, 2],
-    pianoNotes: ['D4', 'F4', 'A4'],
-  },
-];
+import { chordList as chords, type Chord } from '../../data/chords';
 
 const getChord = (name: string): Chord | null =>
   chords.find(c => c.name === name) ?? null;

--- a/src/data/chords.ts
+++ b/src/data/chords.ts
@@ -7,6 +7,7 @@ export interface ChordDefinition {
   pianoNotes: string[];
   guitarPositions: FretPosition[];
   guitarFingers?: number[];
+  level?: number;
 }
 
 export const chords: Record<string, ChordDefinition> = {
@@ -263,5 +264,16 @@ export const chords: Record<string, ChordDefinition> = {
     guitarFingers: [1, 3, 4, 1, 1, 1],
   },
 };
+
+export interface Chord extends ChordDefinition {
+  name: string;
+}
+
+export const chordList: Chord[] = Object.entries(chords).map(
+  ([name, data]) => ({
+    name,
+    ...data,
+  })
+);
 
 export type ChordName = keyof typeof chords;


### PR DESCRIPTION
## Summary
- add shared `Chord` type and list in `data/chords`
- refactor `SongPractice` to use shared chord list
- refactor `PracticeMode` to use shared chord list and optional level filtering

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd922bd9c8332a356a99e1fc99d95