### PR TITLE
Use unique key for song list items

### DIFF
--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -146,7 +146,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
           </h3>
           <ul className="space-y-2">
             {songs.map(song => (
-              <li key={song.title}>
+              <li key={`${song.title}-${song.artist}`}>
                 <button
                   onClick={() => {
                     setSelectedSong(song);


### PR DESCRIPTION
## Summary
- ensure song list items have unique keys by including artist

## Testing
- `npm test` *(fails: 1 test file, 3 tests)*
- `npm run lint` *(fails: 56 problems, 51 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afd9221f3483328eeaf818531e8995