### PR TITLE
Use unique keys and handle optional guitar fingerings

### DIFF
--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -316,7 +316,12 @@ const PracticeMode: FC = () => {
           <InstrumentPanel
             selectedInstrument={selectedInstrument}
             onInstrumentChange={setSelectedInstrument}
-            chord={currentChord}
+            chord={
+              currentChord && {
+                ...currentChord,
+                guitarFingers: currentChord.guitarFingers ?? [],
+              }
+            }
             playGuitarNote={playGuitarNote}
             playPianoNote={note => playChord([note], 0.5, 'piano')}
             initAudio={initAudio}

--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -146,7 +146,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
           </h3>
           <ul className="space-y-2">
             {songs.map(song => (
-              <li key={song.title}>
+              <li key={`${song.title}-${song.artist}`}>
                 <button
                   onClick={() => {
                     setSelectedSong(song);
@@ -198,7 +198,12 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
           <InstrumentPanel
             selectedInstrument={selectedInstrument}
             onInstrumentChange={setSelectedInstrument}
-            chord={currentChord}
+            chord={
+              currentChord && {
+                ...currentChord,
+                guitarFingers: currentChord.guitarFingers ?? [],
+              }
+            }
             playGuitarNote={playGuitarNote}
             playPianoNote={note => playChord([note], 0.5, 'piano')}
             initAudio={initAudio}


### PR DESCRIPTION
## Summary
- ensure song list items have unique keys by including artist
- provide default guitar finger arrays when passing chords to InstrumentPanel

## Testing
- `npm test` *(fails: 1 test file, 3 tests)*
- `npm run lint` *(fails: 56 problems, 51 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afd9221f3483328eeaf818531e8995