### PR TITLE
Refactor InstrumentPanel props and export

### DIFF
--- a/src/components/practice-mode/InstrumentPanel.tsx
+++ b/src/components/practice-mode/InstrumentPanel.tsx
@@ -1,32 +1,15 @@
 import type { FC } from 'react';
-import GuitarDiagram from '../diagrams/GuitarDiagram';
-import PianoDiagram from '../diagrams/PianoDiagram';
 import { GUITAR_ICON, PIANO_ICON } from '../../assets/instrumentIcons';
-
-interface PracticeChord {
-  name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers?: number[];
-  pianoNotes: string[];
-}
 
 interface InstrumentPanelProps {
   selectedInstrument: 'guitar' | 'piano';
   onInstrumentChange: (instrument: 'guitar' | 'piano') => void;
-  chord: PracticeChord | null;
-  playGuitarNote: (string: number, fret: number) => void;
-  playPianoNote: (note: string) => void;
-  initAudio: () => void;
   beginnerMode?: boolean;
 }
 
 const InstrumentPanel: FC<InstrumentPanelProps> = ({
     selectedInstrument,
     onInstrumentChange,
-    chord,
-    playGuitarNote,
-    playPianoNote,
-    initAudio,
     beginnerMode = false,
 }) => {
     return (
@@ -71,4 +54,6 @@ const InstrumentPanel: FC<InstrumentPanelProps> = ({
         {/* ...rest of your component */}
     </div>
 );
-}
+};
+
+export default InstrumentPanel;

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -84,7 +84,7 @@ const PracticeMode: FC = () => {
     const location = useLocation();
     const practicedChordsRef = useRef<Set<string>>(new Set());
     const [keyCenter, setKeyCenter] = useState<MajorKey | null>(null);
-    const { playChord, playGuitarNote, initAudio, fretToNote, guitarLoaded } = useAudio();
+    const { playChord, fretToNote, guitarLoaded } = useAudio();
 
     useEffect(() => {
         if (currentChord && (currentChord.level ?? 1) > highestUnlockedLevel) {
@@ -319,15 +319,11 @@ const PracticeMode: FC = () => {
                         />
                     )}
 
-                    <InstrumentPanel
-                        selectedInstrument={selectedInstrument}
-                        onInstrumentChange={setSelectedInstrument}
-                        chord={currentChord}
-                        playGuitarNote={playGuitarNote}
-                        playPianoNote={note => playChord([note], 0.5, 'piano')}
-                        initAudio={initAudio}
-                        beginnerMode={beginnerMode}
-                    />
+                    <InstrumentPanel
+                        selectedInstrument={selectedInstrument}
+                        onInstrumentChange={setSelectedInstrument}
+                        beginnerMode={beginnerMode}
+                    />
 
                     {selectedInstrument === 'guitar' && !guitarLoaded && (
                         <p className="text-gray-500 text-sm mt-2">Loading sounds...</p>

--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -24,7 +24,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
         useState<'guitar' | 'piano'>('guitar');
     const [message, setMessage] = useState<string | null>(null);
     const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
-    const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
+    const { playChord, fretToNote } = useAudio();
 
     const chordName: string | null =
         selectedSong?.progression[currentChordIndex] ?? null;
@@ -147,15 +147,11 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
                         nextChord={nextChord}
                     />
 
-                    <InstrumentPanel
-                        selectedInstrument={selectedInstrument}
-                        onInstrumentChange={setSelectedInstrument}
-                        chord={currentChord}
-                        playGuitarNote={playGuitarNote}
-                        playPianoNote={note => playChord([note], 0.5, 'piano')}
-                        initAudio={initAudio}
-                    />
-                </div>
+                    <InstrumentPanel
+                        selectedInstrument={selectedInstrument}
+                        onInstrumentChange={setSelectedInstrument}
+                    />
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- simplify InstrumentPanel by removing unused imports and props
- export InstrumentPanel for reuse and adjust parent components

## Testing
- `npm test` *(fails: Unable to find element with text "More Options"; and others)*
- `npm run lint` *(fails: Irregular whitespace not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68afeba8a9f08332a64cba2b10410786