### PR TITLE
refactor: update InstrumentPanel usage to match named export

### DIFF
--- a/src/components/practice-mode/InstrumentPanel.tsx
+++ b/src/components/practice-mode/InstrumentPanel.tsx
@@ -1,74 +1,57 @@
 import type { FC } from 'react';
-import GuitarDiagram from '../diagrams/GuitarDiagram';
-import PianoDiagram from '../diagrams/PianoDiagram';
 import { GUITAR_ICON, PIANO_ICON } from '../../assets/instrumentIcons';
 
-interface PracticeChord {
-  name: string;
-  guitarPositions: { string: number; fret: number }[];
-  guitarFingers?: number[];
-  pianoNotes: string[];
+export interface InstrumentPanelProps {
+  selectedInstrument: 'guitar' | 'piano';
+  onInstrumentChange: (instrument: 'guitar' | 'piano') => void;
+  beginnerMode?: boolean;
 }
 
-interface InstrumentPanelProps {
-  selectedInstrument: 'guitar' | 'piano';
-  onInstrumentChange: (instrument: 'guitar' | 'piano') => void;
-  chord: PracticeChord | null;
-  playGuitarNote: (string: number, fret: number) => void;
-  playPianoNote: (note: string) => void;
-  initAudio: () => void;
-  beginnerMode?: boolean;
-}
-
-const InstrumentPanel: FC<InstrumentPanelProps> = ({
-    selectedInstrument,
-    onInstrumentChange,
-    chord,
-    playGuitarNote,
-    playPianoNote,
-    initAudio,
-    beginnerMode = false,
+export const InstrumentPanel: FC<InstrumentPanelProps> = ({
+  selectedInstrument,
+  onInstrumentChange,
+  beginnerMode = false,
 }) => {
-    return (
+  return (
     <div className="mb-6">
-        {!beginnerMode && (
-            <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Instrument
-                </label>
-                <div className="flex space-x-2 mb-4">
-                    <button
-                        onClick={() => onInstrumentChange('guitar')}
-                        aria-label="Select guitar instrument"
-                        className={`flex flex-col items-center justify-center px-4 py-4 h-24 rounded-lg ${
-                            selectedInstrument === 'guitar'
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
-                        }`}
-                    >
-                        <span className="text-3xl" aria-hidden="true">
-                            {GUITAR_ICON}
-                        </span>
-                        <span className="mt-1 text-sm">Guitar</span>
-                    </button>
-                    <button
-                        onClick={() => onInstrumentChange('piano')}
-                        aria-label="Select piano instrument"
-                        className={`flex flex-col items-center justify-center px-4 py-4 h-24 rounded-lg ${
-                            selectedInstrument === 'piano'
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
-                        }`}
-                    >
-                        <span className="text-3xl" aria-hidden="true">
-                            {PIANO_ICON}
-                        </span>
-                        <span className="mt-1 text-sm">Piano</span>
-                    </button>
-                </div>
-            </div>
-        )}
-        {/* ...rest of your component */}
+      {!beginnerMode && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Instrument
+          </label>
+          <div className="flex space-x-2 mb-4">
+            <button
+              onClick={() => onInstrumentChange('guitar')}
+              aria-label="Select guitar instrument"
+              className={`flex flex-col items-center justify-center px-4 py-4 h-24 rounded-lg ${
+                selectedInstrument === 'guitar'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+              }`}
+            >
+              <span className="text-3xl" aria-hidden="true">
+                {GUITAR_ICON}
+              </span>
+              <span className="mt-1 text-sm">Guitar</span>
+            </button>
+            <button
+              onClick={() => onInstrumentChange('piano')}
+              aria-label="Select piano instrument"
+              className={`flex flex-col items-center justify-center px-4 py-4 h-24 rounded-lg ${
+                selectedInstrument === 'piano'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+              }`}
+            >
+              <span className="text-3xl" aria-hidden="true">
+                {PIANO_ICON}
+              </span>
+              <span className="mt-1 text-sm">Piano</span>
+            </button>
+          </div>
+        </div>
+      )}
+      {/* ...rest of your component */}
     </div>
-);
-}
+  );
+};

--- a/src/components/practice-mode/PracticeMode.tsx
+++ b/src/components/practice-mode/PracticeMode.tsx
@@ -8,7 +8,7 @@ import usePracticeStatistics from '../../hooks/usePracticeStatistics';
 import ChallengeMode from './ChallengeMode';
 import Statistics from './Statistics';
 import PracticeMetronomeControls from './PracticeMetronomeControls';
-import InstrumentPanel from './InstrumentPanel';
+import { InstrumentPanel } from './InstrumentPanel';
 import { chordList as chords, type Chord } from '../../data/chords';
 import SongPractice from './SongPractice';
 import { useHighestUnlockedLevel } from '../learning-path/LearningPathway';
@@ -84,7 +84,7 @@ const PracticeMode: FC = () => {
     const location = useLocation();
     const practicedChordsRef = useRef<Set<string>>(new Set());
     const [keyCenter, setKeyCenter] = useState<MajorKey | null>(null);
-    const { playChord, playGuitarNote, initAudio, fretToNote, guitarLoaded } = useAudio();
+    const { playChord, fretToNote, guitarLoaded } = useAudio();
 
     useEffect(() => {
         if (currentChord && (currentChord.level ?? 1) > highestUnlockedLevel) {
@@ -322,10 +322,6 @@ const PracticeMode: FC = () => {
                     <InstrumentPanel
                         selectedInstrument={selectedInstrument}
                         onInstrumentChange={setSelectedInstrument}
-                        chord={currentChord}
-                        playGuitarNote={playGuitarNote}
-                        playPianoNote={note => playChord([note], 0.5, 'piano')}
-                        initAudio={initAudio}
                         beginnerMode={beginnerMode}
                     />
 

--- a/src/components/practice-mode/SongPractice.tsx
+++ b/src/components/practice-mode/SongPractice.tsx
@@ -3,7 +3,7 @@ import songs, { type Song } from '../../data/songs';
 import useMetronome from '../../hooks/useMetronome';
 import useAudio from '../../hooks/useAudio';
 import PracticeMetronomeControls from './PracticeMetronomeControls';
-import InstrumentPanel from './InstrumentPanel';
+import { InstrumentPanel } from './InstrumentPanel';
 import { chordList as chords, type Chord } from '../../data/chords';
 
 const getChord = (name: string): Chord | null =>
@@ -24,7 +24,7 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
         useState<'guitar' | 'piano'>('guitar');
     const [message, setMessage] = useState<string | null>(null);
     const [{ isPlaying, bpm }, { start, stop, setBpm }] = useMetronome(60, 4);
-    const { playChord, playGuitarNote, initAudio, fretToNote } = useAudio();
+    const { playChord, fretToNote } = useAudio();
 
     const chordName: string | null =
         selectedSong?.progression[currentChordIndex] ?? null;
@@ -150,10 +150,6 @@ const SongPractice: FC<SongPracticeProps> = ({ onClose }) => {
                     <InstrumentPanel
                         selectedInstrument={selectedInstrument}
                         onInstrumentChange={setSelectedInstrument}
-                        chord={currentChord}
-                        playGuitarNote={playGuitarNote}
-                        playPianoNote={note => playChord([note], 0.5, 'piano')}
-                        initAudio={initAudio}
                     />
                 </div>
             )}


### PR DESCRIPTION
## Summary
- refactor InstrumentPanel into a named export with simplified props
- update PracticeMode and SongPractice to use new InstrumentPanel API

## Testing
- `npm test` *(fails: usePracticeStatistics.test.ts, PracticeMode.test.tsx, etc.)*
- `npm run lint` *(fails: irregular whitespace not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68afebaade1c8332b71caadf8761188e