### PR TITLE
Use Node.js 20 for GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- set Node version to 20 in deployment workflow

## Testing
- `npm run build` (fails: TypeScript errors)
- `npm test` (fails: 3 tests failed)


------
https://chatgpt.com/codex/tasks/task_e_68b0073e1ee083328556ba77b9f3f94b