### PR TITLE
Align practice piano diagram with shared keyboard layout

### DIFF
--- a/src/components/diagrams/PianoDiagram.tsx
+++ b/src/components/diagrams/PianoDiagram.tsx
@@ -3,7 +3,7 @@ import { getChordTheme } from '../../utils/diagramTheme';
 import { getChordInversion, getNoteName } from '../../utils/music-theory';
 
 // --- Static Data for Keyboard Layout (from 'main') ---
-const KEYBOARD_LAYOUT = {
+export const KEYBOARD_LAYOUT = {
   whiteKeys: [
     { note: 'F4', position: 0 }, { note: 'G4', position: 1 }, { note: 'A4', position: 2 },
     { note: 'B4', position: 3 }, { note: 'C5', position: 4 }, { note: 'D5', position: 5 },

--- a/src/components/practice-mode/PianoChordDiagram.tsx
+++ b/src/components/practice-mode/PianoChordDiagram.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import './PianoChordDiagram.css';
+import { KEYBOARD_LAYOUT } from '../diagrams/PianoDiagram';
+import { getMidiNumber, getNoteFromMidi, getNoteName } from '../../utils/music-theory';
 
 type PianoChordDiagramProps = {
   notes: string[];
@@ -7,42 +9,37 @@ type PianoChordDiagramProps = {
   color?: string; // Hex color code
 };
 
-const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({ 
-  notes, 
-  chordName, 
+const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
+  notes,
+  chordName,
   color = '#cc39bc' // Default color
 }) => {
-  const activeNotes = notes || [];
-  
-  const keys = [
-    { type: 'white', note: 'C' },
-    { type: 'black', note: 'C#' },
-    { type: 'white', note: 'D' },
-    { type: 'black', note: 'D#' },
-    { type: 'white', note: 'E' },
-    { type: 'white', note: 'F' },
-    { type: 'black', note: 'F#' },
-    { type: 'white', note: 'G' },
-    { type: 'black', note: 'G#' },
-    { type: 'white', note: 'A' },
-    { type: 'black', note: 'A#' },
-    { type: 'white', note: 'B' },
+  const normalizeNote = (note: string) => {
+    const midi = getMidiNumber(note);
+    const standardized = midi !== null ? getNoteFromMidi(midi) : note;
+    return getNoteName(standardized);
+  };
+  const activeNotes = (notes || []).map(normalizeNote);
+
+  const allKeys = [
+    ...KEYBOARD_LAYOUT.whiteKeys.map(k => ({ ...k, type: 'white' as const, root: getNoteName(k.note) })),
+    ...KEYBOARD_LAYOUT.blackKeys.map(k => ({ ...k, type: 'black' as const, root: getNoteName(k.note) })),
   ];
 
   // Calculate positions
-  const whiteKeyWidth = 100 / 11; // 11 white keys in the reference
+  const whiteKeyWidth = 100 / KEYBOARD_LAYOUT.totalWhiteKeys;
 
-  // For black keys: left = (index * whiteKeyWidth) - (whiteKeyWidth * 0.32)
-  const getBlackKeyLeft = (index: number) => {
-    return `calc(${index * whiteKeyWidth}% - ${whiteKeyWidth * 0.32}%)`;
+  // For black keys: left = (position * whiteKeyWidth) - (whiteKeyWidth * 0.32)
+  const getBlackKeyLeft = (position: number) => {
+    return `calc(${position * whiteKeyWidth}% - ${whiteKeyWidth * 0.32}%)`;
   };
 
-  // For fill overlays: left = (index * whiteKeyWidth)% for white keys
-  const getFillLeft = (index: number, isBlack: boolean) => {
+  // For fill overlays: left = (position * whiteKeyWidth)% for white keys
+  const getFillLeft = (position: number, isBlack: boolean) => {
     if (isBlack) {
-      return getBlackKeyLeft(index);
+      return getBlackKeyLeft(position);
     }
-    return `${index * whiteKeyWidth}%`;
+    return `${position * whiteKeyWidth}%`;
   };
 
   // Update fill styles to use dynamic color
@@ -59,63 +56,67 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
         </div>
       )}
       <div className="keyboard-wrap">
-        <div className="keyboard" role="img" aria-label={`${chordName} chord`}>
-          {keys.map((key, index) => {
-            const isActive = activeNotes.includes(key.note);
-            
-            if (key.type === 'white') {
-              return (
-                <div 
-                  key={index}
-                  className={`white-key ${isActive ? 'active' : ''}`}
-                  aria-label={key.note}
-                />
-              );
-            } else {
-              return (
-                <div
-                  key={index}
-                  className={`black-key ${isActive ? 'active' : ''}`}
-                  style={{
-                    left: getBlackKeyLeft(index),
-                  }}
-                  aria-label={key.note}
-                />
-              );
-            }
+        <div
+          className="keyboard"
+          role="img"
+          aria-label={`${chordName} chord`}
+          style={{ gridTemplateColumns: `repeat(${KEYBOARD_LAYOUT.totalWhiteKeys}, 1fr)` }}
+        >
+          {KEYBOARD_LAYOUT.whiteKeys.map(({ note }) => {
+            const isActive = activeNotes.includes(getNoteName(note));
+            return (
+              <div
+                key={note}
+                className={`white-key ${isActive ? 'active' : ''}`}
+                aria-label={note}
+              />
+            );
           })}
-          
+
+          {KEYBOARD_LAYOUT.blackKeys.map(({ note, position }) => {
+            const isActive = activeNotes.includes(getNoteName(note));
+            return (
+              <div
+                key={note}
+                className={`black-key ${isActive ? 'active' : ''}`}
+                style={{
+                  left: getBlackKeyLeft(position),
+                  width: `${whiteKeyWidth * 0.64}%`,
+                }}
+                aria-label={note}
+              />
+            );
+          })}
+
           {/* Fill overlays with dynamic color */}
           {activeNotes.map((note, index) => {
-            const keyIndex = keys.findIndex(k => k.note === note);
-            if (keyIndex === -1) return null;
-            
-            const key = keys[keyIndex];
+            const key = allKeys.find(k => k.root === note);
+            if (!key) return null;
+
             const isBlack = key.type === 'black';
-            
+
             return (
               <div
                 key={`fill-${index}`}
                 className={`fill ${isBlack ? 'fill-black' : 'fill-white'}`}
                 style={{
                   ...fillStyle,
-                  left: getFillLeft(keyIndex, isBlack),
-                  width: isBlack 
-                    ? `calc(${100 / keys.length}% * 0.64)` 
-                    : `calc(${100 / keys.length}%)`,
+                  left: getFillLeft(key.position, isBlack),
+                  width: isBlack
+                    ? `${whiteKeyWidth * 0.64}%`
+                    : `${whiteKeyWidth}%`,
                 }}
               />
             );
           })}
-          
+
           {/* Note indicators with chord color */}
           {activeNotes.map((note, index) => {
-            const keyIndex = keys.findIndex(k => k.note === note);
-            if (keyIndex === -1) return null;
-            
-            const key = keys[keyIndex];
+            const key = allKeys.find(k => k.root === note);
+            if (!key) return null;
+
             const isBlack = key.type === 'black';
-            
+
             return (
               <div
                 key={`note-${index}`}
@@ -123,11 +124,11 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
                 style={{
                   borderColor: color,
                   boxShadow: `0 5px 10px ${color}33`,
-                  left: `calc(${(keyIndex + 0.5) * (100 / keys.length)}%)`,
+                  left: `${(key.position + 0.5) * whiteKeyWidth}%`,
                   top: isBlack ? 'calc(62% - 43px)' : 'calc(100% - 18px - 43px)',
                 }}
               >
-                {note.replace(/\d/, '')}
+                {note}
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
- Export keyboard layout from `PianoDiagram` for reuse
- Refactor `PianoChordDiagram` to use shared layout and total white key count
- Normalize note names and compute positions for accurate active key highlighting

## Testing
- `npm test` *(fails: ReferenceError: document is not defined, localStorage is not defined, etc.)*
- `npm run lint` *(fails: Use an `interface` instead of a `type`, Unsafe return of a value of type `any`)*

------
https://chatgpt.com/codex/tasks/task_e_68b535f24c14833291132b68a23e522e