### PR TITLE
style: enhance piano diagram styling

### DIFF
--- a/src/components/practice-mode/PianoChordDiagram.css
+++ b/src/components/practice-mode/PianoChordDiagram.css
@@ -1,3 +1,4 @@
+
 .piano-chart-container {
   display: flex;
   flex-direction: column;
@@ -6,11 +7,24 @@
   width: 100%;
 }
 
-.chord-name-display {
-  font-size: 24px;
-  font-weight: bold;
-  margin-bottom: 10px;
+/* Sheet and title styles pulled from printable chord charts */
+.sheet {
+  padding: 26px;
+  border: 16px solid;
+  border-radius: 0;
+  box-shadow: 0 10px 28px rgba(0,0,0,.12);
+  position: relative;
+  overflow: hidden;
+}
+
+.title {
   text-align: center;
+  font-size: 46px;
+  font-weight: 800;
+  margin: 0 0 20px;
+  letter-spacing: .4px;
+  z-index: 1;
+  position: relative;
 }
 
 .keyboard-wrap {
@@ -31,6 +45,15 @@
   overflow: hidden;
   background: #ffffff;
   border-radius: 10px;
+}
+
+.keyboard::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: repeating-linear-gradient(to right, rgba(0,0,0,.68) 0 2px, transparent 2px calc(100%/11));
 }
 
 .key {
@@ -55,6 +78,7 @@
   z-index: 5;
 }
 
+
 .note {
   position: absolute;
   transform: translateX(-50%);
@@ -64,39 +88,37 @@
   display: grid;
   place-items: center;
   font-weight: 800;
-  font-size: 22px;
+  font-size: 30px;
   background: #fff;
   border: 4px solid #000;
   color: #000;
   text-shadow: none;
   z-index: 7;
-  box-shadow: 0 5px 10px rgba(0,0,0,0.4);
 }
 
-.white-key.active {
-  background: linear-gradient(to bottom, #ffd86f, #fcb045);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+.note.white {
+  bottom: 18px;
 }
 
-.black-key.active {
-  background: linear-gradient(to bottom, #fcb045, #ff8c00);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.5);
+.note.black {
+  top: calc(62% - 10px - 43px);
 }
 
 .fill {
   position: absolute;
   pointer-events: none;
-  z-index: 4;
 }
 
 .fill-white {
   top: 0;
   height: 100%;
-  background: rgba(204, 57, 188, 0.3); /* Example color, will be set dynamically */
+  z-index: 3;
+  box-shadow: inset 0 0 0 2px #000;
 }
 
 .fill-black {
   top: 0;
   height: 62%;
-  background: rgba(204, 57, 188, 0.3); /* Example color, will be set dynamically */
+  z-index: 6;
+  box-shadow: inset 0 0 0 2px #000;
 }

--- a/src/components/practice-mode/PianoChordDiagram.tsx
+++ b/src/components/practice-mode/PianoChordDiagram.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import './PianoChordDiagram.css';
 
-type PianoChordDiagramProps = {
+interface PianoChordDiagramProps {
   notes: string[];
   chordName?: string;
   color?: string; // Hex color code
-};
+}
 
-const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({ 
-  notes, 
-  chordName, 
+const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
+  notes,
+  chordName,
   color = '#cc39bc' // Default color
 }) => {
   const activeNotes = notes || [];
@@ -47,19 +47,19 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
 
   // Update fill styles to use dynamic color
   const fillStyle = {
-    backgroundColor: `${color}33`, // Add alpha transparency
-    border: `2px solid ${color}`
-  };
+    backgroundColor: color,
+    boxShadow: 'inset 0 0 0 2px #000'
+  } as React.CSSProperties;
 
   return (
     <div className="piano-chart-container">
-      {chordName && (
-        <div className="chord-name-display">
-          {chordName}
-        </div>
-      )}
-      <div className="keyboard-wrap">
-        <div className="keyboard" role="img" aria-label={`${chordName} chord`}>
+      <section
+        className="sheet"
+        style={{ borderColor: color, backgroundColor: `${color}22` }}
+      >
+        {chordName && <h1 className="title">{chordName}</h1>}
+        <div className="keyboard-wrap">
+          <div className="keyboard" role="img" aria-label={`${chordName} chord`}>
           {keys.map((key, index) => {
             const isActive = activeNotes.includes(key.note);
             
@@ -89,10 +89,10 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
           {activeNotes.map((note, index) => {
             const keyIndex = keys.findIndex(k => k.note === note);
             if (keyIndex === -1) return null;
-            
+
             const key = keys[keyIndex];
             const isBlack = key.type === 'black';
-            
+
             return (
               <div
                 key={`fill-${index}`}
@@ -100,31 +100,28 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
                 style={{
                   ...fillStyle,
                   left: getFillLeft(keyIndex, isBlack),
-                  width: isBlack 
-                    ? `calc(${100 / keys.length}% * 0.64)` 
+                  width: isBlack
+                    ? `calc(${100 / keys.length}% * 0.64)`
                     : `calc(${100 / keys.length}%)`,
                 }}
               />
             );
           })}
-          
-          {/* Note indicators with chord color */}
+
+          {/* Note indicators */}
           {activeNotes.map((note, index) => {
             const keyIndex = keys.findIndex(k => k.note === note);
             if (keyIndex === -1) return null;
-            
+
             const key = keys[keyIndex];
             const isBlack = key.type === 'black';
-            
+
             return (
               <div
                 key={`note-${index}`}
                 className={`note ${isBlack ? 'black' : 'white'}`}
                 style={{
-                  borderColor: color,
-                  boxShadow: `0 5px 10px ${color}33`,
                   left: `calc(${(keyIndex + 0.5) * (100 / keys.length)}%)`,
-                  top: isBlack ? 'calc(62% - 43px)' : 'calc(100% - 18px - 43px)',
                 }}
               >
                 {note.replace(/\d/, '')}
@@ -133,6 +130,7 @@ const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
           })}
         </div>
       </div>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- style piano practice diagram with sheet container and title
- add vertical grid lines and solid color overlays
- adjust note sizing and positioning

## Testing
- `npm test` *(fails: document is not defined)*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b535f361ec8332ae352f31448a9cea