### PR TITLE
Use chord theme color by default in piano diagram

### DIFF
--- a/src/components/practice-mode/PianoChordDiagram.tsx
+++ b/src/components/practice-mode/PianoChordDiagram.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './PianoChordDiagram.css';
+import { getChordTheme } from '../../utils/diagramTheme';
 
 type PianoChordDiagramProps = {
   notes: string[];
@@ -7,11 +8,12 @@ type PianoChordDiagramProps = {
   color?: string; // Hex color code
 };
 
-const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({ 
-  notes, 
-  chordName, 
-  color = '#cc39bc' // Default color
+const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({
+  notes,
+  chordName,
+  color
 }) => {
+  color = color ?? getChordTheme(chordName ?? '').primary;
   const activeNotes = notes || [];
   
   const keys = [


### PR DESCRIPTION
## Summary
- Derive piano chord diagram color from the chord theme when no color is provided
- Remove hard-coded default color in PianoChordDiagram

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined, document is not defined, etc.)*
- `npm run lint` *(fails: Use an interface instead of a type, unsafe returns in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b53687fae883328495b69ea96ab451