### PR TITLE
Refactor guitar chord diagram O/X markers to share xo class

### DIFF
--- a/src/components/practice-mode/GuitarChordDiagram.css
+++ b/src/components/practice-mode/GuitarChordDiagram.css
@@ -36,19 +36,11 @@
   border-left: 2px solid #666;
 }
 
-.string-indicator {
+.xo {
   position: absolute;
-  font-size: 18px;
+  font-size: 32px;
   font-weight: bold;
-  color: #333;
-}
-
-.open-symbol {
-  color: green;
-}
-
-.mute-symbol {
-  color: red;
+  transform: translate(-50%, -100%);
 }
 
 .fret-position {

--- a/src/components/practice-mode/GuitarChordDiagram.tsx
+++ b/src/components/practice-mode/GuitarChordDiagram.tsx
@@ -110,10 +110,14 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
         {/* Open and muted strings */}
         {openStrings.map((open, i) => (
           open && (
-            <div 
+            <div
               key={`open-${i}`}
-              className="string-indicator open-symbol"
-              style={{ left: `${i * 20}%`, top: '-15%' }}
+              className="xo"
+              style={{
+                left: `${i * 20}%`,
+                top: '0',
+                color: 'var(--chord-color)',
+              }}
             >
               {open}
             </div>
@@ -121,10 +125,14 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
         ))}
         {mutedStrings.map((muted, i) => (
           muted && (
-            <div 
+            <div
               key={`muted-${i}`}
-              className="string-indicator mute-symbol"
-              style={{ left: `${i * 20}%`, top: '-15%' }}
+              className="xo"
+              style={{
+                left: `${i * 20}%`,
+                top: '0',
+                color: 'var(--chord-color)',
+              }}
             >
               {muted}
             </div>
@@ -167,14 +175,11 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
             width: 0;
             border-top: 1px solid #666;
           }
-          .string-indicator {
+          .xo {
             position: absolute;
-            width: 20px;
-            text-align: center;
-          }
-          .open-symbol, .mute-symbol {
-            font-size: 18px;
+            font-size: 32px;
             font-weight: bold;
+            transform: translate(-50%, -100%);
           }
           .barre {
             position: absolute;


### PR DESCRIPTION
## Summary
- Replace separate open/mute classes with shared `xo` styling
- Render O/X markers with dynamic chord color and translated positioning

## Testing
- `npm test -- --run` *(fails: ReferenceError: document/window/localStorage not defined)*
- `npm run lint` *(fails: ESLint issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b53625ca888332a657b41fd22c6c23