### PR TITLE
feat: style guitar chord dots and barres

### DIFF
--- a/src/components/practice-mode/ChordDisplay.tsx
+++ b/src/components/practice-mode/ChordDisplay.tsx
@@ -3,10 +3,10 @@ import GuitarChordDiagram from './GuitarChordDiagram';
 import PianoChordDiagram from './PianoChordDiagram';
 import type { Chord } from '../../data/chords';
 
-type ChordDisplayProps = {
+interface ChordDisplayProps {
   chord: Chord | null;
   instrument: 'guitar' | 'piano';
-};
+}
 
 const ChordDisplay: React.FC<ChordDisplayProps> = ({ chord, instrument }) => {
   if (!chord) {
@@ -21,10 +21,10 @@ const ChordDisplay: React.FC<ChordDisplayProps> = ({ chord, instrument }) => {
         </div>
         
         {instrument === 'guitar' ? (
-          <GuitarChordDiagram positions={chord.guitarPositions} />
+          <GuitarChordDiagram positions={chord.guitarPositions} color={chord.color} />
         ) : (
-          <PianoChordDiagram 
-            notes={chord.pianoNotes} 
+          <PianoChordDiagram
+            notes={chord.pianoNotes}
             chordName={chord.name}
           />
         )}

--- a/src/components/practice-mode/GuitarChordDiagram.tsx
+++ b/src/components/practice-mode/GuitarChordDiagram.tsx
@@ -10,9 +10,10 @@ export interface GuitarPosition {
 
 interface GuitarPositionProps {
   positions: GuitarPosition[];
+  color?: string;
 }
 
-const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
+const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions, color = '#000' }) => {
   // Calculate barre chords
   const barreChords = useMemo(() => {
     const barres: Record<number, { fret: number; startString: number; endString: number }> = {};
@@ -30,8 +31,8 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
   }, [positions]);
 
   // Calculate open and muted strings
-  const openStrings = useMemo(() => {
-    const strings = Array(6).fill('');
+  const openStrings = useMemo((): string[] => {
+    const strings = Array<string>(6).fill('');
     positions.forEach(pos => {
       if (pos.fret === 0) {
         strings[6 - pos.string] = 'O';
@@ -40,11 +41,11 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
     return strings;
   }, [positions]);
 
-  const mutedStrings = useMemo(() => {
-    const strings = Array(6).fill('');
+  const mutedStrings = useMemo((): string[] => {
+    const strings = Array<string>(6).fill('');
     const hasFret = positions.some(p => p.fret > 0);
     if (!hasFret) return strings;
-    
+
     for (let i = 0; i < 6; i++) {
       if (!positions.some(p => p.string === 6 - i && p.fret > 0)) {
         strings[i] = 'X';
@@ -70,50 +71,70 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
         
         {/* Strings */}
         {Array.from({ length: 6 }).map((_, i) => (
-          <div 
+          <div
             key={i}
-            className="string-line" 
-            style={{ left: `${i * 20}%` }}
+            className="string-line"
+            style={{ left: `${(i + 0.5) * (100 / 6)}%` }}
           />
         ))}
         
         {/* Barre chords */}
-        {barreChords.map((barre, idx) => (
-          <div
-            key={idx}
-            className="barre"
-            style={{
-              top: `${(barre.fret - 0.5) * 20}%`,
-              left: `${(6 - barre.endString) * 20}%`,
-              width: `${(barre.endString - barre.startString) * 20}%`,
-              height: '10px',
-            }}
-          />
-        ))}
+        {barreChords.map((barre, idx) => {
+          const segment = 100 / 6;
+          const left = (6 - barre.endString + 0.5) * segment;
+          const width = (barre.endString - barre.startString) * segment;
+          return (
+            <div
+              key={idx}
+              className="barre"
+              style={{
+                top: `${(barre.fret - 0.5) * 20}%`,
+                left: `${left}%`,
+                width: `${width}%`,
+                '--cc': color,
+              } as React.CSSProperties}
+            >
+              1
+            </div>
+          );
+        })}
         
         {/* Positions */}
         {positions
-          .filter(p => p.fret > 0)
-          .map((pos, idx) => (
-            <div
-              key={idx}
-              className={`fret-position ${pos.isRoot ? 'root' : ''}`}
-              style={{
-                top: `${(pos.fret - 0.5) * 20}%`,
-                left: `${(6 - pos.string) * 20}%`,
-              }}
-            >
-              {pos.finger}
-            </div>
-          ))}
+          .filter(p =>
+            p.fret > 0 &&
+            !barreChords.some(
+              barre =>
+                p.finger === 1 &&
+                p.fret === barre.fret &&
+                p.string >= barre.startString &&
+                p.string <= barre.endString
+            )
+          )
+          .map((pos, idx) => {
+            const segment = 100 / 6;
+            return (
+              <div
+                key={idx}
+                className="dot"
+                style={{
+                  top: `${(pos.fret - 0.5) * 20}%`,
+                  left: `${(6 - pos.string + 0.5) * segment}%`,
+                  '--cc': color,
+                } as React.CSSProperties}
+              >
+                {pos.finger}
+              </div>
+            );
+          })}
         
         {/* Open and muted strings */}
         {openStrings.map((open, i) => (
           open && (
-            <div 
+            <div
               key={`open-${i}`}
               className="string-indicator open-symbol"
-              style={{ left: `${i * 20}%`, top: '-15%' }}
+              style={{ left: `${(i + 0.5) * (100 / 6)}%`, top: '-15%' }}
             >
               {open}
             </div>
@@ -121,10 +142,10 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
         ))}
         {mutedStrings.map((muted, i) => (
           muted && (
-            <div 
+            <div
               key={`muted-${i}`}
               className="string-indicator mute-symbol"
-              style={{ left: `${i * 20}%`, top: '-15%' }}
+              style={{ left: `${(i + 0.5) * (100 / 6)}%`, top: '-15%' }}
             >
               {muted}
             </div>
@@ -143,8 +164,8 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
           }
           .fretboard {
             position: relative;
-            width: 120px;
-            height: 160px;
+            width: 360px;
+            height: 360px;
             background-color: #fff;
             border: 1px solid #ddd;
           }
@@ -163,9 +184,11 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
           }
           .string-line {
             position: absolute;
+            top: 0;
             height: 100%;
             width: 0;
-            border-top: 1px solid #666;
+            border-left: 2px solid #666;
+            transform: translateX(-50%);
           }
           .string-indicator {
             position: absolute;
@@ -178,20 +201,33 @@ const GuitarChordDiagram: React.FC<GuitarPositionProps> = ({ positions }) => {
           }
           .barre {
             position: absolute;
-            background-color: #000;
-            border-radius: 5px;
-          }
-          .fret-position {
-            position: absolute;
-            border-radius: 50%;
+            transform: translateY(-50%);
+            height: 48px;
+            border-radius: 999px;
+            background: var(--cc);
+            color: #fff;
             display: flex;
             justify-content: center;
             align-items: center;
-            border: 3px solid #000;
+            font-weight: 800;
+            font-size: 24px;
             box-shadow: 0 3px 6px rgba(0,0,0,0.3);
           }
-          .root {
-            background-color: #ff6b6b;
+          .dot {
+            position: absolute;
+            transform: translate(-50%, -50%);
+            width: 72px;
+            height: 72px;
+            border-radius: 999px;
+            background: var(--cc);
+            color: #fff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-weight: 800;
+            font-size: 30px;
+            text-shadow: 0 1px 0 rgba(0,0,0,0.25);
+            box-shadow: 0 3px 6px rgba(0,0,0,0.3);
           }
         `}
       </style>

--- a/src/components/practice-mode/PianoChordDiagram.tsx
+++ b/src/components/practice-mode/PianoChordDiagram.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import './PianoChordDiagram.css';
 
-type PianoChordDiagramProps = {
+interface PianoChordDiagramProps {
   notes: string[];
   chordName?: string;
   color?: string; // Hex color code
-};
+}
 
 const PianoChordDiagram: React.FC<PianoChordDiagramProps> = ({ 
   notes, 


### PR DESCRIPTION
## Summary
- style guitar chord diagram dots using .dot class with color variable
- render barre chords with centered labels and shared color
- pass chord color to guitar diagram

## Testing
- `npm test` (fails: document is not defined)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5362e93a8833292fd8f09e2dd9896